### PR TITLE
Add a Chip component

### DIFF
--- a/README.md
+++ b/README.md
@@ -20,7 +20,7 @@
 
 - Breadcrumbs
 - Slider
-- Chips/Tags
+- ~~Chips/Tags~~
 - ~~Progress Bar~~
 - ~~Loader~~
 - ~~Toast~~

--- a/src/components/Chip/Chip.module.css
+++ b/src/components/Chip/Chip.module.css
@@ -1,0 +1,3 @@
+.Chip {
+  display: flex;
+}

--- a/src/components/Chip/Chip.module.css
+++ b/src/components/Chip/Chip.module.css
@@ -1,3 +1,4 @@
-.Chip {
+.container {
   display: flex;
+  cursor: pointer;
 }

--- a/src/components/Chip/Chip.stories.tsx
+++ b/src/components/Chip/Chip.stories.tsx
@@ -1,0 +1,38 @@
+import { action } from "@storybook/addon-actions"
+import { ComponentMeta, Story } from "@storybook/react"
+import { ComponentProps } from "react"
+import { Chip } from "./Chip"
+
+/**
+ * See Storybook Docs: Writing Stories
+ * https://storybook.js.org/docs/basics/writing-stories/
+ */
+
+export default {
+  title: "Components/Chip",
+} as ComponentMeta<typeof Chip>
+
+const Template: Story<ComponentProps<typeof Chip>> = (args) => (
+  <Chip {...args} />
+)
+
+export const Default = Template.bind({})
+
+Default.args = {
+  children: <div>Example Chip</div>,
+  onSelect: action("onSelect"),
+  onClose: action("onClose"),
+}
+
+export const WithoutClose = Template.bind({})
+
+WithoutClose.args = {
+  children: <div>Example Chip</div>,
+  onSelect: action("onSelect"),
+}
+
+export const WithoutEvents = Template.bind({})
+
+WithoutEvents.args = {
+  children: <div>Example Chip</div>,
+}

--- a/src/components/Chip/Chip.test.tsx
+++ b/src/components/Chip/Chip.test.tsx
@@ -1,0 +1,136 @@
+import { render, screen } from "@testing-library/react"
+import userEvent from "@testing-library/user-event"
+import { Chip } from "./Chip"
+
+describe("Chip", () => {
+  it("renders the expected structure with no default props", () => {
+    // Arrange
+    const children = "Test Chip"
+
+    // Act
+    render(<Chip>{children}</Chip>)
+
+    const chipSelectElement = screen.getByText(children)
+    const closeElement = screen.queryByLabelText("close")
+
+    // Assert
+    expect(chipSelectElement).toBeInTheDocument()
+    expect(closeElement).toBeNull()
+  })
+
+  it("calls onClose when the closeElement is pressed", async () => {
+    // Arrange
+    const children = "Test Chip"
+    const closeElement = <>Close</>
+    const onClose = jest.fn()
+
+    // Act
+    render(
+      <Chip onClose={onClose} closeElement={closeElement}>
+        {children}
+      </Chip>,
+    )
+
+    const receivedCloseElement = screen.getByLabelText("close")
+    await userEvent.click(receivedCloseElement)
+
+    // Assert
+    expect(receivedCloseElement).toBeInTheDocument()
+    expect(receivedCloseElement).toHaveTextContent("Close")
+    expect(onClose).toHaveBeenCalledTimes(1)
+  })
+
+  it("calls onSelect when the main element is clicked", async () => {
+    // Arrange
+    const children = "Test Chip"
+    const onSelect = jest.fn()
+
+    // Act
+    render(<Chip onSelect={onSelect}>{children}</Chip>)
+
+    const received = screen.getByText(children)
+    await userEvent.click(received)
+
+    // Assert
+    expect(received).toBeInTheDocument()
+    expect(onSelect).toHaveBeenCalledTimes(1)
+  })
+
+  it("calls onSelect when the main element is tabbed to and then enter is pressed", async () => {
+    // Arrange
+    const children = "Test Chip"
+    const onSelect = jest.fn()
+
+    // Act
+    render(<Chip onSelect={onSelect}>{children}</Chip>)
+
+    const received = screen.getByText(children)
+    await userEvent.tab()
+    await userEvent.keyboard("{enter}")
+
+    // Assert
+    expect(received).toBeInTheDocument()
+    expect(onSelect).toHaveBeenCalledTimes(1)
+  })
+
+  it("does not call onSelect when the main element is tabbed to and then any other key is pressed", async () => {
+    // Arrange
+    const children = "Test Chip"
+    const onSelect = jest.fn()
+
+    // Act
+    render(<Chip onSelect={onSelect}>{children}</Chip>)
+
+    const received = screen.getByText(children)
+    await userEvent.tab()
+    await userEvent.keyboard("{space}")
+
+    // Assert
+    expect(received).toBeInTheDocument()
+    expect(onSelect).toHaveBeenCalledTimes(0)
+  })
+
+  it("calls onClose when the close element is tabbed to and then enter is pressed", async () => {
+    // Arrange
+    const children = "Test Chip"
+    const closeElement = <>Close</>
+    const onClose = jest.fn()
+
+    // Act
+    render(
+      <Chip onClose={onClose} closeElement={closeElement}>
+        {children}
+      </Chip>,
+    )
+
+    const receivedCloseElement = screen.getByLabelText("close")
+    await userEvent.tab()
+    await userEvent.keyboard("{enter}")
+
+    // Assert
+    expect(receivedCloseElement).toBeInTheDocument()
+    expect(onClose).toHaveBeenCalledTimes(1)
+  })
+
+  it("does not call onClose when the close element is tabbed to and then any other key is pressed", async () => {
+    // Arrange
+    const children = "Test Chip"
+    const closeElement = <>Close</>
+    const onClose = jest.fn()
+
+    // Act
+    render(
+      <Chip onClose={onClose} closeElement={closeElement}>
+        {children}
+      </Chip>,
+    )
+
+    const receivedCloseElement = screen.getByLabelText("close")
+    await userEvent.tab()
+    await userEvent.keyboard("{space}")
+
+    // Assert
+    expect(receivedCloseElement).toBeInTheDocument()
+    expect(onClose).toHaveBeenCalledTimes(0)
+  })
+})

--- a/src/components/Chip/Chip.tsx
+++ b/src/components/Chip/Chip.tsx
@@ -1,0 +1,50 @@
+import { ReactNode } from "react"
+import styles from "./Chip.module.css"
+
+export interface ChipProps {
+  children?: ReactNode
+  onSelect?: () => unknown
+  onClose?: () => unknown
+  closeElement?: ReactNode
+}
+
+export function Chip({
+  children,
+  closeElement = <span>&times;</span>,
+  onSelect,
+  onClose,
+}: ChipProps) {
+  return (
+    <div className={styles.Chip}>
+      <div
+        onClick={onSelect}
+        // these next 3 props are important for a11y
+        role={onSelect ? "button" : undefined}
+        tabIndex={onSelect ? 0 : undefined}
+        onKeyDown={(e) => {
+          if (e.code === "Enter") {
+            onSelect?.()
+          }
+        }}
+      >
+        {children}
+      </div>
+      {onClose ? (
+        <div
+          onClick={onClose}
+          // these next 4 props are important for a11y
+          role="button"
+          aria-label="close"
+          tabIndex={0}
+          onKeyDown={(e) => {
+            if (e.code === "Enter") {
+              onClose?.()
+            }
+          }}
+        >
+          {closeElement}
+        </div>
+      ) : null}
+    </div>
+  )
+}

--- a/src/components/Chip/Chip.tsx
+++ b/src/components/Chip/Chip.tsx
@@ -2,7 +2,7 @@ import { ReactNode } from "react"
 import styles from "./Chip.module.css"
 
 export interface ChipProps {
-  children?: ReactNode
+  children: ReactNode
   onSelect?: () => unknown
   onClose?: () => unknown
   closeElement?: ReactNode
@@ -15,7 +15,7 @@ export function Chip({
   onClose,
 }: ChipProps) {
   return (
-    <div className={styles.Chip}>
+    <div className={styles.container}>
       <div
         onClick={onSelect}
         // these next 3 props are important for a11y

--- a/src/components/Chip/README.md
+++ b/src/components/Chip/README.md
@@ -1,0 +1,14 @@
+# `<Chip />`
+
+This component is meant to represent a "chip" or "tag" component to be displayed on their own or in a list of sorts. The can have both a "select" and a "close"
+action. The `onSelect` action is called when a user clicks or presses enter when focused on the `children` of the Element. The `onClose` action is called when a user clicks or presses enter on either the supplied `closeElement` or the default close icon.
+
+By default there are minimal styles pre applied to this component.
+
+## Directory Structure
+
+- `Chip.stories.tsx`: Component stories (`npm run test:playground`)
+- `Chip.test.tsx`: Component tests (`npm run test:unit`)
+- `Chip.tsx`: Component code
+- `index.ts`: Component export
+- `README.md`: Component documentation (hey, that's me!)

--- a/src/components/Chip/index.ts
+++ b/src/components/Chip/index.ts
@@ -1,0 +1,1 @@
+export { Chip } from "./Chip"


### PR DESCRIPTION
## Description

This PR adds a basic chip component used to show "chip" or "tag" like information. The component supports `onSelect` and `onClose` actions with keyboard support and a replaceable `closeElement` prop.

### 🖼 Demo

<img width="133" alt="Screen Shot 2022-08-02 at 4 04 23 PM" src="https://user-images.githubusercontent.com/6101761/182473472-993e1ecf-5197-40f7-b8be-f440e3d37dbd.png">


https://user-images.githubusercontent.com/6101761/182473488-550c586e-90f7-4eab-8c55-5ea24dae883f.mov


<!-- If applicable, use "Before/After Table" located at end of file -->

## 🔎 Reviewer Checklist

> _Checked off by PR **Reviewers**_

- [ ] Merge destination is correct
- [ ] Code is correct as understood and conforms to quality standards
- [ ] Tests have been added where appropriate (unit, visual, end-to-end)
- [ ] Acceptance Criteria have been met

<!--
Optional additions:
- [ ] Code has been tested and confirmed locally
-->

---

> ### Roles & Responsibilities
>
> #### 👨‍💻 Assignee
>
> - Initiator of this PR (be sure to set in GitHub UI)
> - Addresses feedback and change requests
> - Merges PR once approved (usually deletes branch unless `develop` or `release`)
>
> #### 👩‍💻 Reviewer
>
> - Invited to review PR by **Assignee** (via GitHub UI)
> - Is expected to complete a review and address followup

<!--
## Before/After Table

<table>
<tr><th>Before</th><th>After</th></tr>
<tr>
<td>

![](BEFORE_IMAGE_LINK_HERE)

</td>
<td>

![](AFTER_IMAGE_LINK_HERE)

</td>
</tr>
</table>
-->
