### PR TITLE
Feature/tooltip

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -8,11 +8,12 @@
       "name": "crema-app-web",
       "version": "0.1.0",
       "dependencies": {
-        "@types/react-transition-group": "^4.4.5",
+        "@popperjs/core": "^2.11.5",
         "classnames": "^2.3.1",
         "react": "18.1.0",
         "react-dom": "18.1.0",
         "react-focus-lock": "^2.9.1",
+        "react-popper": "^2.3.0",
         "react-scripts": "5.0.1",
         "react-transition-group": "^4.4.2",
         "web-vitals": "2.1.4"
@@ -39,6 +40,7 @@
         "@types/node": "16.11.36",
         "@types/react": "18.0.9",
         "@types/react-dom": "18.0.4",
+        "@types/react-transition-group": "^4.4.5",
         "change-case": "4.1.2",
         "cross-env": "7.0.3",
         "cypress": "9.6.1",
@@ -4065,10 +4067,9 @@
       }
     },
     "node_modules/@popperjs/core": {
-      "version": "2.11.4",
-      "resolved": "https://registry.npmjs.org/@popperjs/core/-/core-2.11.4.tgz",
-      "integrity": "sha512-q/ytXxO5NKvyT37pmisQAItCFqA7FD/vNb8dgaJy3/630Fsc+Mz9/9f2SziBoIZ30TJooXyTwZmhi1zjXmObYg==",
-      "dev": true,
+      "version": "2.11.5",
+      "resolved": "https://registry.npmjs.org/@popperjs/core/-/core-2.11.5.tgz",
+      "integrity": "sha512-9X2obfABZuDVLCgPK9aX0a/x4jaOEweTTWE2+9sr0Qqqevj2Uv5XorvusThmc9XGYpS9yI+fhh8RTafBtGposw==",
       "funding": {
         "type": "opencollective",
         "url": "https://opencollective.com/popperjs"
@@ -12699,6 +12700,7 @@
     },
     "node_modules/@types/prop-types": {
       "version": "15.7.4",
+      "dev": true,
       "license": "MIT"
     },
     "node_modules/@types/q": {
@@ -12725,6 +12727,7 @@
       "version": "18.0.9",
       "resolved": "https://registry.npmjs.org/@types/react/-/react-18.0.9.tgz",
       "integrity": "sha512-9bjbg1hJHUm4De19L1cHiW0Jvx3geel6Qczhjd0qY5VKVE2X5+x77YxAepuCwVh4vrgZJdgEJw48zrhRIeF4Nw==",
+      "dev": true,
       "dependencies": {
         "@types/prop-types": "*",
         "@types/scheduler": "*",
@@ -12753,6 +12756,7 @@
       "version": "4.4.5",
       "resolved": "https://registry.npmjs.org/@types/react-transition-group/-/react-transition-group-4.4.5.tgz",
       "integrity": "sha512-juKD/eiSM3/xZYzjuzH6ZwpP+/lejltmiS3QEzV/vmb/Q8+HfDmxu+Baga8UEMGBqV88Nbg4l2hY/K2DkyaLLA==",
+      "dev": true,
       "dependencies": {
         "@types/react": "*"
       }
@@ -12760,7 +12764,8 @@
     "node_modules/@types/react/node_modules/csstype": {
       "version": "3.1.0",
       "resolved": "https://registry.npmjs.org/csstype/-/csstype-3.1.0.tgz",
-      "integrity": "sha512-uX1KG+x9h5hIJsaKR9xHUeUraxf8IODOwq9JLNPq6BwB04a/xgpq3rcx47l5BZu5zBPlgD342tdke3Hom/nJRA=="
+      "integrity": "sha512-uX1KG+x9h5hIJsaKR9xHUeUraxf8IODOwq9JLNPq6BwB04a/xgpq3rcx47l5BZu5zBPlgD342tdke3Hom/nJRA==",
+      "dev": true
     },
     "node_modules/@types/resolve": {
       "version": "1.17.1",
@@ -12775,6 +12780,7 @@
     },
     "node_modules/@types/scheduler": {
       "version": "0.16.2",
+      "dev": true,
       "license": "MIT"
     },
     "node_modules/@types/serve-index": {
@@ -32166,8 +32172,7 @@
     "node_modules/react-fast-compare": {
       "version": "3.2.0",
       "resolved": "https://registry.npmjs.org/react-fast-compare/-/react-fast-compare-3.2.0.tgz",
-      "integrity": "sha512-rtGImPZ0YyLrscKI9xTpV8psd6I8VAtjKCzQDlzyDvqJA8XOW78TXYQwNRNd8g8JZnDu8q9Fu/1v4HPAVwVdHA==",
-      "dev": true
+      "integrity": "sha512-rtGImPZ0YyLrscKI9xTpV8psd6I8VAtjKCzQDlzyDvqJA8XOW78TXYQwNRNd8g8JZnDu8q9Fu/1v4HPAVwVdHA=="
     },
     "node_modules/react-focus-lock": {
       "version": "2.9.1",
@@ -32231,17 +32236,17 @@
       "license": "MIT"
     },
     "node_modules/react-popper": {
-      "version": "2.2.5",
-      "resolved": "https://registry.npmjs.org/react-popper/-/react-popper-2.2.5.tgz",
-      "integrity": "sha512-kxGkS80eQGtLl18+uig1UIf9MKixFSyPxglsgLBxlYnyDf65BiY9B3nZSc6C9XUNDgStROB0fMQlTEz1KxGddw==",
-      "dev": true,
+      "version": "2.3.0",
+      "resolved": "https://registry.npmjs.org/react-popper/-/react-popper-2.3.0.tgz",
+      "integrity": "sha512-e1hj8lL3uM+sgSR4Lxzn5h1GxBlpa4CQz0XLF8kx4MDrDRWY0Ena4c97PUeSX9i5W3UAfDP0z0FXCTQkoXUl3Q==",
       "dependencies": {
         "react-fast-compare": "^3.0.1",
         "warning": "^4.0.2"
       },
       "peerDependencies": {
         "@popperjs/core": "^2.0.0",
-        "react": "^16.8.0 || ^17"
+        "react": "^16.8.0 || ^17 || ^18",
+        "react-dom": "^16.8.0 || ^17 || ^18"
       }
     },
     "node_modules/react-popper-tooltip": {
@@ -37702,7 +37707,6 @@
     },
     "node_modules/warning": {
       "version": "4.0.3",
-      "dev": true,
       "license": "MIT",
       "dependencies": {
         "loose-envify": "^1.0.0"
@@ -41898,10 +41902,9 @@
       }
     },
     "@popperjs/core": {
-      "version": "2.11.4",
-      "resolved": "https://registry.npmjs.org/@popperjs/core/-/core-2.11.4.tgz",
-      "integrity": "sha512-q/ytXxO5NKvyT37pmisQAItCFqA7FD/vNb8dgaJy3/630Fsc+Mz9/9f2SziBoIZ30TJooXyTwZmhi1zjXmObYg==",
-      "dev": true
+      "version": "2.11.5",
+      "resolved": "https://registry.npmjs.org/@popperjs/core/-/core-2.11.5.tgz",
+      "integrity": "sha512-9X2obfABZuDVLCgPK9aX0a/x4jaOEweTTWE2+9sr0Qqqevj2Uv5XorvusThmc9XGYpS9yI+fhh8RTafBtGposw=="
     },
     "@reach/router": {
       "version": "1.3.4",
@@ -48419,7 +48422,8 @@
       "dev": true
     },
     "@types/prop-types": {
-      "version": "15.7.4"
+      "version": "15.7.4",
+      "dev": true
     },
     "@types/q": {
       "version": "1.5.4"
@@ -48441,6 +48445,7 @@
       "version": "18.0.9",
       "resolved": "https://registry.npmjs.org/@types/react/-/react-18.0.9.tgz",
       "integrity": "sha512-9bjbg1hJHUm4De19L1cHiW0Jvx3geel6Qczhjd0qY5VKVE2X5+x77YxAepuCwVh4vrgZJdgEJw48zrhRIeF4Nw==",
+      "dev": true,
       "requires": {
         "@types/prop-types": "*",
         "@types/scheduler": "*",
@@ -48450,7 +48455,8 @@
         "csstype": {
           "version": "3.1.0",
           "resolved": "https://registry.npmjs.org/csstype/-/csstype-3.1.0.tgz",
-          "integrity": "sha512-uX1KG+x9h5hIJsaKR9xHUeUraxf8IODOwq9JLNPq6BwB04a/xgpq3rcx47l5BZu5zBPlgD342tdke3Hom/nJRA=="
+          "integrity": "sha512-uX1KG+x9h5hIJsaKR9xHUeUraxf8IODOwq9JLNPq6BwB04a/xgpq3rcx47l5BZu5zBPlgD342tdke3Hom/nJRA==",
+          "dev": true
         }
       }
     },
@@ -48476,6 +48482,7 @@
       "version": "4.4.5",
       "resolved": "https://registry.npmjs.org/@types/react-transition-group/-/react-transition-group-4.4.5.tgz",
       "integrity": "sha512-juKD/eiSM3/xZYzjuzH6ZwpP+/lejltmiS3QEzV/vmb/Q8+HfDmxu+Baga8UEMGBqV88Nbg4l2hY/K2DkyaLLA==",
+      "dev": true,
       "requires": {
         "@types/react": "*"
       }
@@ -48490,7 +48497,8 @@
       "version": "0.12.1"
     },
     "@types/scheduler": {
-      "version": "0.16.2"
+      "version": "0.16.2",
+      "dev": true
     },
     "@types/serve-index": {
       "version": "1.9.1",
@@ -62124,8 +62132,7 @@
     "react-fast-compare": {
       "version": "3.2.0",
       "resolved": "https://registry.npmjs.org/react-fast-compare/-/react-fast-compare-3.2.0.tgz",
-      "integrity": "sha512-rtGImPZ0YyLrscKI9xTpV8psd6I8VAtjKCzQDlzyDvqJA8XOW78TXYQwNRNd8g8JZnDu8q9Fu/1v4HPAVwVdHA==",
-      "dev": true
+      "integrity": "sha512-rtGImPZ0YyLrscKI9xTpV8psd6I8VAtjKCzQDlzyDvqJA8XOW78TXYQwNRNd8g8JZnDu8q9Fu/1v4HPAVwVdHA=="
     },
     "react-focus-lock": {
       "version": "2.9.1",
@@ -62170,10 +62177,9 @@
       "dev": true
     },
     "react-popper": {
-      "version": "2.2.5",
-      "resolved": "https://registry.npmjs.org/react-popper/-/react-popper-2.2.5.tgz",
-      "integrity": "sha512-kxGkS80eQGtLl18+uig1UIf9MKixFSyPxglsgLBxlYnyDf65BiY9B3nZSc6C9XUNDgStROB0fMQlTEz1KxGddw==",
-      "dev": true,
+      "version": "2.3.0",
+      "resolved": "https://registry.npmjs.org/react-popper/-/react-popper-2.3.0.tgz",
+      "integrity": "sha512-e1hj8lL3uM+sgSR4Lxzn5h1GxBlpa4CQz0XLF8kx4MDrDRWY0Ena4c97PUeSX9i5W3UAfDP0z0FXCTQkoXUl3Q==",
       "requires": {
         "react-fast-compare": "^3.0.1",
         "warning": "^4.0.2"
@@ -66094,7 +66100,6 @@
     },
     "warning": {
       "version": "4.0.3",
-      "dev": true,
       "requires": {
         "loose-envify": "^1.0.0"
       }

--- a/package.json
+++ b/package.json
@@ -3,10 +3,12 @@
   "version": "0.1.0",
   "private": true,
   "dependencies": {
+    "@popperjs/core": "^2.11.5",
     "classnames": "^2.3.1",
     "react": "18.1.0",
     "react-dom": "18.1.0",
     "react-focus-lock": "^2.9.1",
+    "react-popper": "^2.3.0",
     "react-scripts": "5.0.1",
     "react-transition-group": "^4.4.2",
     "web-vitals": "2.1.4"

--- a/src/components/Tooltip/README.md
+++ b/src/components/Tooltip/README.md
@@ -23,20 +23,20 @@ For advance use cases, explore the Tooltip stories in our storybook.
 
 ## API
 
-| Prop                | Type      | Required | Description                     | Default |
-| ------------------- | --------- | -------- | ------------------------------- | ------- |
-| `children`          | ReactNode | yes      | the anchor element              |         |
-| `label`             | string    | yes      | the tooltip text                |         |
-| `distance`          | number    | no       | distance from anchor            | 10      |
-| `skidding`          | number    | no       | vertical/horizontal alignment   | 0       |
-| `showArrow`         | boolean   | no       | a tooltip with an arrow         |         |
-| `alwaysShow`        | boolean   | no       | tooltip always shown            |         |
-| `hideOnClick`       | boolean   | no       | onClick hides tooltip           |         |
-| `enterDelay`        | number    | no       | entry delay in ms               |         |
-| `exitDelay`         | number    | no       | exit delay in ms                |         |
-| `placement`         | string    | no       | positioning relative to anchor  | "auto"  |
-| `animationDuration` | number    | no       | duration in ms                  | 300     |
-| `ariaDescribedBy`   | string    | no       | link anchor and tooltip id      | 300     |
+| Prop                | Type      | Required | Description                    | Default |
+| ------------------- | --------- | -------- | ------------------------------ | ------- |
+| `children`          | ReactNode | yes      | the anchor element             |         |
+| `label`             | string    | yes      | the tooltip text               |         |
+| `distance`          | number    | no       | distance from anchor           | 10      |
+| `skidding`          | number    | no       | vertical/horizontal alignment  | 0       |
+| `showArrow`         | boolean   | no       | a tooltip with an arrow        |         |
+| `alwaysShow`        | boolean   | no       | tooltip always shown           |         |
+| `hideOnClick`       | boolean   | no       | onClick hides tooltip          |         |
+| `enterDelay`        | number    | no       | entry delay in ms              |         |
+| `exitDelay`         | number    | no       | exit delay in ms               |         |
+| `placement`         | string    | no       | positioning relative to anchor | "auto"  |
+| `animationDuration` | number    | no       | duration in ms                 | 300     |
+| `ariaDescribedBy`   | string    | no       | link anchor and tooltip id     | 300     |
 
 ## Food for thought from MDN
 

--- a/src/components/Tooltip/README.md
+++ b/src/components/Tooltip/README.md
@@ -1,6 +1,6 @@
 # `<Tooltip />`
 
-DESCRIPTION_HERE
+A simple tooltip component for displaying non-interactive descriptive text that is anchored to its child element. Supports keyboard accessibility.
 
 ## Directory Structure
 
@@ -9,3 +9,41 @@ DESCRIPTION_HERE
 - `Tooltip.tsx`: Component code
 - `index.ts`: Component export
 - `README.md`: Component documentation (hey, that's me!)
+- `placements.ts`: Exports an array of all possible tooltip placements
+
+## Example Usage
+
+Basic Usage
+
+```tsx
+<Tooltip label="World">Hello</Tooltip>
+```
+
+For advance use cases, explore the Tooltip stories in our storybook.
+
+## API
+
+| Prop                | Type      | Required | Description                     | Default |
+| ------------------- | --------- | -------- | ------------------------------- | ------- |
+| `children`          | ReactNode | yes      | the anchor element              |         |
+| `label`             | string    | yes      | the tooltip text                |         |
+| `distance`          | number    | no       | distance from anchor            | 10      |
+| `skidding`          | number    | no       | vertical/horizontal alignment   | 0       |
+| `showArrow`         | boolean   | no       | a tooltip with an arrow         |         |
+| `alwaysShow`        | boolean   | no       | tooltip always shown            |         |
+| `hideOnClick`       | boolean   | no       | onClick hides tooltip           |         |
+| `enterDelay`        | number    | no       | entry delay in ms               |         |
+| `exitDelay`         | number    | no       | exit delay in ms                |         |
+| `placement`         | string    | no       | positioning relative to anchor  | "auto"  |
+| `animationDuration` | number    | no       | duration in ms                  | 300     |
+| `ariaDescribedBy`   | string    | no       | link anchor and tooltip id      | 300     |
+
+## Food for thought from MDN
+
+### Accessibility Concerns
+
+If the information is important enough for a tooltip, isn't it important enough to always be visible?
+
+### Best Practices
+
+Instead of using tooltips and hiding important information, consider writing clear, succinct, always visible descriptions. If you have space, don't use tooltips or toggletips. Just provide clear labels and sufficient body text.

--- a/src/components/Tooltip/README.md
+++ b/src/components/Tooltip/README.md
@@ -1,0 +1,11 @@
+# `<Tooltip />`
+
+DESCRIPTION_HERE
+
+## Directory Structure
+
+- `Tooltip.stories.tsx`: Component stories (`npm run test:playground`)
+- `Tooltip.test.tsx`: Component tests (`npm run test:unit`)
+- `Tooltip.tsx`: Component code
+- `index.ts`: Component export
+- `README.md`: Component documentation (hey, that's me!)

--- a/src/components/Tooltip/Tooltip.module.css
+++ b/src/components/Tooltip/Tooltip.module.css
@@ -15,6 +15,7 @@
 
 .box {
   padding: 4px 8px;
+  max-width: 250px;
   background: #444444;
   color: #ffffff;
   font-size: 14px;

--- a/src/components/Tooltip/Tooltip.module.css
+++ b/src/components/Tooltip/Tooltip.module.css
@@ -13,10 +13,6 @@
   background: #444444;
 }
 
-.box[data-is-open="false"] {
-  visibility: hidden;
-}
-
 .box {
   padding: 4px 8px;
   background: #444444;
@@ -42,13 +38,6 @@
   left: -4px;
 }
 
-.container {
-  position: absolute;
-}
-
-.wrapper {
-  position: relative;
-}
 
 
 

--- a/src/components/Tooltip/Tooltip.module.css
+++ b/src/components/Tooltip/Tooltip.module.css
@@ -38,8 +38,3 @@
 .box[data-popper-placement^="right"] > .arrow {
   left: -4px;
 }
-
-
-
-
-

--- a/src/components/Tooltip/Tooltip.module.css
+++ b/src/components/Tooltip/Tooltip.module.css
@@ -19,6 +19,7 @@
   background: #444444;
   color: #ffffff;
   font-size: 14px;
+  line-height: 21px;
   border-radius: 2px;
   filter: drop-shadow(0 0 0.1rem #999999);
 }

--- a/src/components/Tooltip/Tooltip.module.css
+++ b/src/components/Tooltip/Tooltip.module.css
@@ -4,7 +4,7 @@
   width: 8px;
 }
 
-.arrow:after {
+.arrow::after {
   position: absolute;
   content: "";
   transform: rotate(45deg);

--- a/src/components/Tooltip/Tooltip.module.css
+++ b/src/components/Tooltip/Tooltip.module.css
@@ -1,0 +1,55 @@
+.arrow {
+  position: absolute;
+  height: 8px;
+  width: 8px;
+}
+
+.arrow:after {
+  position: absolute;
+  content: "";
+  transform: rotate(45deg);
+  height: 8px;
+  width: 8px;
+  background: #444444;
+}
+
+.box[data-is-open="false"] {
+  visibility: hidden;
+}
+
+.box {
+  padding: 4px 8px;
+  background: #444444;
+  color: #ffffff;
+  font-size: 14px;
+  border-radius: 2px;
+  filter: drop-shadow(0 0 0.1rem #999999);
+}
+
+.box[data-popper-placement^="top"] > .arrow {
+  bottom: -4px;
+}
+
+.box[data-popper-placement^="bottom"] > .arrow {
+  top: -4px;
+}
+
+.box[data-popper-placement^="left"] > .arrow {
+  right: -4px;
+}
+
+.box[data-popper-placement^="right"] > .arrow {
+  left: -4px;
+}
+
+.container {
+  position: absolute;
+}
+
+.wrapper {
+  position: relative;
+}
+
+
+
+

--- a/src/components/Tooltip/Tooltip.stories.tsx
+++ b/src/components/Tooltip/Tooltip.stories.tsx
@@ -1,0 +1,14 @@
+import decoratorCentered from "@storybook/addon-centered"
+import { Tooltip } from "./Tooltip"
+
+/**
+ * See Storybook Docs: Writing Stories
+ * https://storybook.js.org/docs/basics/writing-stories/
+ */
+
+export default {
+  title: "Tooltip",
+  decorators: [decoratorCentered],
+}
+
+export const Example = () => <Tooltip />

--- a/src/components/Tooltip/Tooltip.stories.tsx
+++ b/src/components/Tooltip/Tooltip.stories.tsx
@@ -1,15 +1,12 @@
 import decoratedCenter from "@storybook/addon-centered"
 import { ComponentStory } from "@storybook/react"
+import { placements } from "./placements"
 import { Tooltip } from "./Tooltip"
 
 /**
  * See Storybook Docs: Writing Stories
  * https://storybook.js.org/docs/basics/writing-stories/
  */
-
-const basePlacement = ["top", "bottom", "left", "right", "auto"]
-const startPlacement = basePlacement.map((placement) => `${placement}-start`)
-const endPlacement = basePlacement.map((placement) => `${placement}-end`)
 
 export default {
   title: "Components/Tooltip",
@@ -18,7 +15,7 @@ export default {
     placement: {
       control: {
         type: "select",
-        options: [...basePlacement, ...startPlacement, ...endPlacement],
+        options: placements,
       },
     },
   },
@@ -60,30 +57,26 @@ WithoutArrow.args = {
 
 export const WithAdditionalContent: ComponentStory<typeof Tooltip> = (args) => {
   return (
-    <div style={{ display: "flex", alignItems: "center" }}>
-      <div>
-        <p>
-          Lorem ipsum dolor sit amet, consectetur adipiscing elit. Pellentesque
-          in ipsum id orci porta dapibus.
-        </p>
-      </div>
-      <div>
-        <p>Some text above.</p>
-        <Tooltip {...args} />
-        <p>Some text below.</p>
-      </div>
-      <div>
-        <p>
-          Lorem ipsum dolor sit amet, consectetur adipiscing elit. Pellentesque
-          in ipsum id orci porta dapibus.
-        </p>
-      </div>
+    <div
+      style={{
+        lineHeight: "24px",
+        width: 400,
+      }}
+    >
+      <p>
+        This is a tooltip that lives within a <Tooltip {...args} />. Tooltips
+        can be very handy for communicating additional information within a body
+        of text :).
+      </p>
     </div>
   )
 }
 
 WithAdditionalContent.args = {
   ...Default.args,
+  children: <b>paragraph</b>,
+  label:
+    "a distinct section of a piece of writing, usually dealing with a single theme and indicated by a new line, indentation, or numbering.",
   showArrow: true,
   placement: "bottom",
   alwaysShow: false,

--- a/src/components/Tooltip/Tooltip.stories.tsx
+++ b/src/components/Tooltip/Tooltip.stories.tsx
@@ -39,6 +39,8 @@ Default.args = {
   showArrow: false,
   enterDelay: 0,
   exitDelay: 0,
+  hideOnClick: false,
+  alwaysShow: false,
 }
 
 export const WithArrow = Template.bind({})

--- a/src/components/Tooltip/Tooltip.stories.tsx
+++ b/src/components/Tooltip/Tooltip.stories.tsx
@@ -1,4 +1,5 @@
-import decoratorCentered from "@storybook/addon-centered"
+import decoratedCenter from "@storybook/addon-centered"
+import { ComponentStory } from "@storybook/react"
 import { Tooltip } from "./Tooltip"
 
 /**
@@ -6,9 +7,117 @@ import { Tooltip } from "./Tooltip"
  * https://storybook.js.org/docs/basics/writing-stories/
  */
 
+const basePlacement = ["top", "bottom", "left", "right", "auto"]
+const startPlacement = basePlacement.map((placement) => `${placement}-start`)
+const endPlacement = basePlacement.map((placement) => `${placement}-end`)
+
 export default {
-  title: "Tooltip",
-  decorators: [decoratorCentered],
+  title: "Components/Tooltip",
+  decorators: [decoratedCenter],
+  argTypes: {
+    placement: {
+      control: {
+        type: "select",
+        options: [...basePlacement, ...startPlacement, ...endPlacement],
+      },
+    },
+  },
 }
 
-export const Example = () => <Tooltip />
+const Template: ComponentStory<typeof Tooltip> = (args) => {
+  return <Tooltip {...args} />
+}
+
+export const Default = Template.bind({})
+
+Default.args = {
+  children: "Hello",
+  label: "World",
+  horizontalOffset: 10,
+  verticalOffset: 0,
+  placement: "bottom",
+  showArrow: false,
+  enterDelay: 0,
+  exitDelay: 0,
+}
+
+export const WithArrow = Template.bind({})
+
+WithArrow.args = {
+  ...Default.args,
+  alwaysShow: true,
+  showArrow: true,
+}
+
+export const WithoutArrow = Template.bind({})
+
+WithoutArrow.args = {
+  ...Default.args,
+  alwaysShow: true,
+}
+
+export const WithAdditionalContent: ComponentStory<typeof Tooltip> = (args) => {
+  return (
+    <div style={{ display: "flex", alignItems: "center" }}>
+      <div>
+        <p>
+          Lorem ipsum dolor sit amet, consectetur adipiscing elit. Pellentesque
+          in ipsum id orci porta dapibus.
+        </p>
+      </div>
+      <div>
+        <p>Some text above.</p>
+        <Tooltip {...args} />
+        <p>Some text below.</p>
+      </div>
+      <div>
+        <p>
+          Lorem ipsum dolor sit amet, consectetur adipiscing elit. Pellentesque
+          in ipsum id orci porta dapibus.
+        </p>
+      </div>
+    </div>
+  )
+}
+
+WithAdditionalContent.args = {
+  ...Default.args,
+  showArrow: true,
+  placement: "bottom",
+  alwaysShow: false,
+}
+
+export const PlacementTop = Template.bind({})
+
+PlacementTop.args = {
+  ...Default.args,
+  placement: "top",
+  alwaysShow: true,
+  showArrow: true,
+}
+export const PlacementRight = Template.bind({})
+
+PlacementRight.args = {
+  ...Default.args,
+  placement: "right",
+  alwaysShow: true,
+  showArrow: true,
+}
+
+export const PlacementBottom = Template.bind({})
+
+PlacementBottom.args = {
+  ...Default.args,
+  placement: "bottom",
+  alwaysShow: true,
+  showArrow: true,
+}
+
+export const PlacementLeft = Template.bind({})
+
+PlacementLeft.args = {
+  ...Default.args,
+  placement: "left",
+  alwaysShow: true,
+  showArrow: true,
+}

--- a/src/components/Tooltip/Tooltip.stories.tsx
+++ b/src/components/Tooltip/Tooltip.stories.tsx
@@ -1,5 +1,5 @@
-import decoratedCenter from "@storybook/addon-centered"
 import { ComponentStory } from "@storybook/react"
+import { FC } from "react"
 import { placements } from "./placements"
 import { Tooltip } from "./Tooltip"
 
@@ -10,7 +10,19 @@ import { Tooltip } from "./Tooltip"
 
 export default {
   title: "Components/Tooltip",
-  decorators: [decoratedCenter],
+  decorators: [
+    (Story: FC) => (
+      <div
+        style={{
+          display: "flex",
+          justifyContent: "center",
+          margin: "5rem",
+        }}
+      >
+        <Story />
+      </div>
+    ),
+  ],
   argTypes: {
     placement: {
       control: {

--- a/src/components/Tooltip/Tooltip.stories.tsx
+++ b/src/components/Tooltip/Tooltip.stories.tsx
@@ -8,21 +8,21 @@ import { Tooltip } from "./Tooltip"
  * https://storybook.js.org/docs/basics/writing-stories/
  */
 
+const tooltipDecorator = (Story: FC) => (
+  <div
+    style={{
+      display: "flex",
+      justifyContent: "center",
+      margin: "5rem",
+    }}
+  >
+    <Story />
+  </div>
+)
+
 export default {
   title: "Components/Tooltip",
-  decorators: [
-    (Story: FC) => (
-      <div
-        style={{
-          display: "flex",
-          justifyContent: "center",
-          margin: "5rem",
-        }}
-      >
-        <Story />
-      </div>
-    ),
-  ],
+  decorators: [tooltipDecorator],
   argTypes: {
     placement: {
       control: {

--- a/src/components/Tooltip/Tooltip.stories.tsx
+++ b/src/components/Tooltip/Tooltip.stories.tsx
@@ -30,8 +30,8 @@ export const Default = Template.bind({})
 Default.args = {
   children: "Hello",
   label: "World",
-  horizontalOffset: 10,
-  verticalOffset: 0,
+  distance: 10,
+  skidding: 0,
   placement: "bottom",
   showArrow: false,
   enterDelay: 0,

--- a/src/components/Tooltip/Tooltip.test.tsx
+++ b/src/components/Tooltip/Tooltip.test.tsx
@@ -15,12 +15,12 @@ describe("Tooltip", () => {
 
     const receivedChild = screen.getByText(children)
 
-    expect(screen.getByTestId(testId)).not.toBeVisible()
+    expect(screen.queryByTestId(testId)).not.toBeInTheDocument()
 
     await userEvent.hover(receivedChild)
 
     // Assert
-    expect(screen.getByTestId(testId)).toBeVisible()
+    expect(screen.getByTestId(testId)).toBeInTheDocument()
   })
   it("hides tooltip onMouseLeave", async () => {
     // Arrange
@@ -35,12 +35,14 @@ describe("Tooltip", () => {
 
     await userEvent.hover(receivedChild)
 
-    expect(screen.getByTestId(testId)).toBeVisible()
+    expect(screen.getByTestId(testId)).toBeInTheDocument()
 
     await userEvent.unhover(receivedChild)
 
     // Assert
-    expect(screen.getByTestId(testId)).not.toBeVisible()
+    await waitFor(() =>
+      expect(screen.queryByTestId(testId)).not.toBeInTheDocument(),
+    )
   })
   it("can be focused and escaped by keyboard events", async () => {
     // Arrange
@@ -54,15 +56,17 @@ describe("Tooltip", () => {
     // Assert
     await userEvent.tab()
 
-    expect(screen.getByTestId(testId)).not.toBeVisible()
+    expect(screen.queryByTestId(testId)).not.toBeInTheDocument()
 
     await userEvent.keyboard("[Enter]")
 
-    expect(screen.getByTestId(testId)).toBeVisible()
+    expect(screen.getByTestId(testId)).toBeInTheDocument()
 
     await userEvent.keyboard("[Escape]")
 
-    expect(screen.getByTestId(testId)).not.toBeVisible()
+    await waitFor(() =>
+      expect(screen.queryByTestId(testId)).not.toBeInTheDocument(),
+    )
   })
   it("can be dismissed by clicking anchor element", async () => {
     // Arrange
@@ -82,11 +86,13 @@ describe("Tooltip", () => {
     // Assert
     await userEvent.hover(receivedChildren)
 
-    expect(screen.getByTestId(testId)).toBeVisible()
+    expect(screen.getByTestId(testId)).toBeInTheDocument()
 
     await userEvent.click(receivedChildren)
 
-    expect(screen.getByTestId(testId)).not.toBeVisible()
+    await waitFor(() =>
+      expect(screen.queryByTestId(testId)).not.toBeInTheDocument(),
+    )
   })
   it("can always be shown", async () => {
     // Arrange
@@ -108,13 +114,13 @@ describe("Tooltip", () => {
 
     await userEvent.keyboard("[Escape]")
 
-    expect(screen.getByTestId(testId)).toBeVisible()
+    expect(screen.getByTestId(testId)).toBeInTheDocument()
 
     await userEvent.hover(receivedChildren)
 
     await userEvent.unhover(receivedChildren)
 
-    expect(screen.getByTestId(testId)).toBeVisible()
+    expect(screen.getByTestId(testId)).toBeInTheDocument()
   })
   /* 
   We are making this async since this component internally sets state within a ref callback,
@@ -128,7 +134,7 @@ describe("Tooltip", () => {
 
     // Act
     render(
-      <Tooltip showArrow label={label}>
+      <Tooltip alwaysShow showArrow label={label}>
         {children}
       </Tooltip>,
     )
@@ -164,23 +170,25 @@ describe("Tooltip", () => {
     // Assert
     await user.hover(receivedChildren)
 
-    expect(screen.getByTestId(testId)).not.toBeVisible()
+    expect(screen.queryByTestId(testId)).not.toBeInTheDocument()
 
     act(() => {
       jest.advanceTimersByTime(enterDelay)
     })
 
-    expect(screen.getByTestId(testId)).toBeVisible()
+    await screen.findByTestId(testId)
 
     await user.unhover(receivedChildren)
 
-    expect(screen.getByTestId(testId)).toBeVisible()
+    expect(screen.getByTestId(testId)).toBeInTheDocument()
 
     act(() => {
       jest.advanceTimersByTime(exitDelay)
     })
 
-    expect(screen.getByTestId(testId)).not.toBeVisible()
+    await waitFor(() =>
+      expect(screen.queryByTestId(testId)).not.toBeInTheDocument(),
+    )
     jest.useRealTimers()
   })
   it("supports aria-describedby", async () => {

--- a/src/components/Tooltip/Tooltip.test.tsx
+++ b/src/components/Tooltip/Tooltip.test.tsx
@@ -5,26 +5,28 @@ import { Tooltip } from "./Tooltip"
 
 describe("Tooltip", () => {
   it("displays tooltip onMouseEnter", async () => {
-    // Arrange
+    // ArrTestId
     const children = "Hello"
     const label = "World"
+    const testId = "tooltip"
 
     // Act
     render(<Tooltip label={label}>{children}</Tooltip>)
 
     const receivedChild = screen.getByText(children)
 
-    expect(screen.getByText(label)).not.toBeVisible()
+    expect(screen.getByTestId(testId)).not.toBeVisible()
 
     await userEvent.hover(receivedChild)
 
     // Assert
-    expect(screen.getByText(label)).toBeVisible()
+    expect(screen.getByTestId(testId)).toBeVisible()
   })
   it("hides tooltip onMouseLeave", async () => {
     // Arrange
     const children = "Hello"
     const label = "World"
+    const testId = "tooltip"
 
     // Act
     render(<Tooltip label={label}>{children}</Tooltip>)
@@ -33,17 +35,18 @@ describe("Tooltip", () => {
 
     await userEvent.hover(receivedChild)
 
-    expect(screen.getByText(label)).toBeVisible()
+    expect(screen.getByTestId(testId)).toBeVisible()
 
     await userEvent.unhover(receivedChild)
 
     // Assert
-    expect(screen.getByText(label)).not.toBeVisible()
+    expect(screen.getByTestId(testId)).not.toBeVisible()
   })
   it("can be focused and escaped by keyboard events", async () => {
     // Arrange
     const children = "Hello"
     const label = "World"
+    const testId = "tooltip"
 
     // Act
     render(<Tooltip label={label}>{children}</Tooltip>)
@@ -51,20 +54,21 @@ describe("Tooltip", () => {
     // Assert
     await userEvent.tab()
 
-    expect(screen.getByText(label)).not.toBeVisible()
+    expect(screen.getByTestId(testId)).not.toBeVisible()
 
     await userEvent.keyboard("[Enter]")
 
-    expect(screen.getByText(label)).toBeVisible()
+    expect(screen.getByTestId(testId)).toBeVisible()
 
     await userEvent.keyboard("[Escape]")
 
-    expect(screen.getByText(label)).not.toBeVisible()
+    expect(screen.getByTestId(testId)).not.toBeVisible()
   })
   it("can be dismissed by clicking anchor element", async () => {
     // Arrange
     const children = "Hello"
     const label = "World"
+    const testId = "tooltip"
 
     // Act
     render(
@@ -78,16 +82,17 @@ describe("Tooltip", () => {
     // Assert
     await userEvent.hover(receivedChildren)
 
-    expect(screen.getByText(label)).toBeVisible()
+    expect(screen.getByTestId(testId)).toBeVisible()
 
     await userEvent.click(receivedChildren)
 
-    expect(screen.getByText(label)).not.toBeVisible()
+    expect(screen.getByTestId(testId)).not.toBeVisible()
   })
   it("can always be shown", async () => {
     // Arrange
     const children = "Hello"
     const label = "World"
+    const testId = "tooltip"
 
     // Act
     render(
@@ -103,13 +108,13 @@ describe("Tooltip", () => {
 
     await userEvent.keyboard("[Escape]")
 
-    expect(screen.getByText(label)).toBeVisible()
+    expect(screen.getByTestId(testId)).toBeVisible()
 
     await userEvent.hover(receivedChildren)
 
     await userEvent.unhover(receivedChildren)
 
-    expect(screen.getByText(label)).toBeVisible()
+    expect(screen.getByTestId(testId)).toBeVisible()
   })
   /* 
   We are making this async since this component internally sets state within a ref callback,
@@ -119,7 +124,7 @@ describe("Tooltip", () => {
     // Arrange
     const children = "Hello"
     const label = "World"
-    const arrowTestID = "tooltip_arrow"
+    const arrowTestId = "tooltip_arrow"
 
     // Act
     render(
@@ -128,7 +133,7 @@ describe("Tooltip", () => {
       </Tooltip>,
     )
 
-    const received = screen.getByTestId(arrowTestID)
+    const received = screen.getByTestId(arrowTestId)
 
     // Assert
     await waitFor(() => expect(received).toBeInTheDocument())
@@ -143,6 +148,7 @@ describe("Tooltip", () => {
     const user = userEvent.setup({ delay: null })
     const children = "Hello"
     const label = "World"
+    const testId = "tooltip"
     const enterDelay = 300
     const exitDelay = 500
 
@@ -158,30 +164,31 @@ describe("Tooltip", () => {
     // Assert
     await user.hover(receivedChildren)
 
-    expect(screen.getByText(label)).not.toBeVisible()
+    expect(screen.getByTestId(testId)).not.toBeVisible()
 
     act(() => {
       jest.advanceTimersByTime(enterDelay)
     })
 
-    expect(screen.getByText(label)).toBeVisible()
+    expect(screen.getByTestId(testId)).toBeVisible()
 
     await user.unhover(receivedChildren)
 
-    expect(screen.getByText(label)).toBeVisible()
+    expect(screen.getByTestId(testId)).toBeVisible()
 
     act(() => {
       jest.advanceTimersByTime(exitDelay)
     })
 
-    expect(screen.getByText(label)).not.toBeVisible()
+    expect(screen.getByTestId(testId)).not.toBeVisible()
   })
   it("supports aria-describedby", async () => {
     // Arrange
     jest.useRealTimers()
     const ariaDescribedBy = "paragraphtext"
     const children = <b>paragraph</b>
-    const spanTestID = "tooltip_span"
+    const spanTestId = "tooltip_span"
+    const testId = "tooltip"
     const label =
       "a distinct section of a piece of writing, usually dealing with a single theme and indicated by a new line, indentation, or numbering."
 
@@ -189,7 +196,7 @@ describe("Tooltip", () => {
     render(
       <p>
         This is a tooltip that lives within a{" "}
-        <Tooltip label={label} ariaDescribedBy={ariaDescribedBy}>
+        <Tooltip label={label} aria-describedby={ariaDescribedBy}>
           {children}
         </Tooltip>
         . Tooltips can be very handy for communicating additional information
@@ -197,11 +204,11 @@ describe("Tooltip", () => {
       </p>,
     )
 
-    const receivedWrapper = screen.getByTestId(spanTestID)
+    const receivedWrapper = screen.getByTestId(spanTestId)
 
     await userEvent.hover(receivedWrapper)
 
-    const receivedTooltip = screen.getByText(label)
+    const receivedTooltip = screen.getByTestId(testId)
 
     // Assert
     expect(receivedWrapper).toHaveAttribute("aria-describedby", ariaDescribedBy)

--- a/src/components/Tooltip/Tooltip.test.tsx
+++ b/src/components/Tooltip/Tooltip.test.tsx
@@ -181,10 +181,10 @@ describe("Tooltip", () => {
     })
 
     expect(screen.getByTestId(testId)).not.toBeVisible()
+    jest.useRealTimers()
   })
   it("supports aria-describedby", async () => {
     // Arrange
-    jest.useRealTimers()
     const ariaDescribedBy = "paragraphtext"
     const children = <b>paragraph</b>
     const spanTestId = "tooltip_span"

--- a/src/components/Tooltip/Tooltip.test.tsx
+++ b/src/components/Tooltip/Tooltip.test.tsx
@@ -1,0 +1,7 @@
+import { Tooltip } from "./Tooltip"
+
+describe("Tooltip", () => {
+  it("is defined", expect(Tooltip).toBeDefined)
+
+  it.todo(`add meaningful tests 👍`)
+})

--- a/src/components/Tooltip/Tooltip.test.tsx
+++ b/src/components/Tooltip/Tooltip.test.tsx
@@ -1,7 +1,42 @@
+import { render, screen } from "@testing-library/react"
+import userEvent from "@testing-library/user-event"
 import { Tooltip } from "./Tooltip"
 
 describe("Tooltip", () => {
-  it("is defined", expect(Tooltip).toBeDefined)
+  it("displays tooltip onMouseEnter", async () => {
+    // Arrange
+    const children = "Hello"
+    const label = "World"
 
-  it.todo(`add meaningful tests 👍`)
+    // Act
+    render(<Tooltip label={label}>{children}</Tooltip>)
+
+    const receivedChild = screen.getByText(children)
+
+    expect(screen.getByText(label)).not.toBeVisible()
+
+    await userEvent.hover(receivedChild)
+
+    // Assert
+    expect(screen.getByText(label)).toBeVisible()
+  })
+  it("hides tooltip onMouseLeave", async () => {
+    // Arrange
+    const children = "Hello"
+    const label = "World"
+
+    // Act
+    render(<Tooltip label={label}>{children}</Tooltip>)
+
+    const receivedChild = screen.getByText(children)
+
+    await userEvent.hover(receivedChild)
+
+    expect(screen.getByText(label)).toBeVisible()
+
+    await userEvent.unhover(receivedChild)
+
+    // Assert
+    expect(screen.getByText(label)).not.toBeVisible()
+  })
 })

--- a/src/components/Tooltip/Tooltip.test.tsx
+++ b/src/components/Tooltip/Tooltip.test.tsx
@@ -1,5 +1,5 @@
-import { render, screen, waitFor } from "@testing-library/react"
 import userEvent from "@testing-library/user-event"
+import { act, render, screen, waitFor } from "@testing-library/react"
 import { placements } from "./placements"
 import { Tooltip } from "./Tooltip"
 
@@ -135,6 +135,12 @@ describe("Tooltip", () => {
   })
   it("allows for an enterDelay or exitDelay to be set", async () => {
     // Arrange
+    jest.useFakeTimers()
+    /*
+      when using fake timers we have to set delay to null, 
+      otherwise the userEvent never resolves
+    */
+    const user = userEvent.setup({ delay: null })
     const children = "Hello"
     const label = "World"
     const enterDelay = 300
@@ -150,24 +156,29 @@ describe("Tooltip", () => {
     const receivedChildren = screen.getByText(children)
 
     // Assert
-    await userEvent.hover(receivedChildren)
+    await user.hover(receivedChildren)
 
     expect(screen.getByText(label)).not.toBeVisible()
 
-    await waitFor(() => expect(screen.getByText(label)).toBeVisible(), {
-      timeout: enterDelay,
+    act(() => {
+      jest.advanceTimersByTime(enterDelay)
     })
-
-    await userEvent.unhover(receivedChildren)
 
     expect(screen.getByText(label)).toBeVisible()
 
-    await waitFor(() => expect(screen.getByText(label)).not.toBeVisible(), {
-      timeout: exitDelay,
+    await user.unhover(receivedChildren)
+
+    expect(screen.getByText(label)).toBeVisible()
+
+    act(() => {
+      jest.advanceTimersByTime(exitDelay)
     })
+
+    expect(screen.getByText(label)).not.toBeVisible()
   })
   it("supports aria-describedby", async () => {
     // Arrange
+    jest.useRealTimers()
     const ariaDescribedBy = "paragraphtext"
     const children = <b>paragraph</b>
     const spanTestID = "tooltip_span"

--- a/src/components/Tooltip/Tooltip.test.tsx
+++ b/src/components/Tooltip/Tooltip.test.tsx
@@ -1,5 +1,6 @@
-import { render, screen } from "@testing-library/react"
+import { render, screen, waitFor } from "@testing-library/react"
 import userEvent from "@testing-library/user-event"
+import { placements } from "./placements"
 import { Tooltip } from "./Tooltip"
 
 describe("Tooltip", () => {
@@ -38,5 +39,154 @@ describe("Tooltip", () => {
 
     // Assert
     expect(screen.getByText(label)).not.toBeVisible()
+  })
+  it("can be focused and escaped by keyboard events", async () => {
+    // Arrange
+    const children = "Hello"
+    const label = "World"
+
+    // Act
+    render(<Tooltip label={label}>{children}</Tooltip>)
+
+    // Assert
+    await userEvent.tab()
+
+    expect(screen.getByText(label)).not.toBeVisible()
+
+    await userEvent.keyboard("[Enter]")
+
+    expect(screen.getByText(label)).toBeVisible()
+
+    await userEvent.keyboard("[Escape]")
+
+    expect(screen.getByText(label)).not.toBeVisible()
+  })
+  it("can be dismissed by clicking anchor element", async () => {
+    // Arrange
+    const children = "Hello"
+    const label = "World"
+
+    // Act
+    render(
+      <Tooltip hideOnClick label={label}>
+        {children}
+      </Tooltip>,
+    )
+
+    const receivedChildren = screen.getByText(children)
+
+    // Assert
+    await userEvent.hover(receivedChildren)
+
+    expect(screen.getByText(label)).toBeVisible()
+
+    await userEvent.click(receivedChildren)
+
+    expect(screen.getByText(label)).not.toBeVisible()
+  })
+  it("can always be shown", async () => {
+    // Arrange
+    const children = "Hello"
+    const label = "World"
+
+    // Act
+    render(
+      <Tooltip alwaysShow label={label}>
+        {children}
+      </Tooltip>,
+    )
+
+    const receivedChildren = screen.getByText(children)
+
+    // Assert
+    await userEvent.tab()
+
+    await userEvent.keyboard("[Escape]")
+
+    expect(screen.getByText(label)).toBeVisible()
+
+    await userEvent.hover(receivedChildren)
+
+    await userEvent.unhover(receivedChildren)
+
+    expect(screen.getByText(label)).toBeVisible()
+  })
+  /* 
+  We are making this async since this component internally sets state within a ref callback,
+  otherwise testing library complains about state being set and not wrapping fireEvent in 'act' 
+  */
+  it("can display an optional arrow element", async () => {
+    // Arrange
+    const children = "Hello"
+    const label = "World"
+    const arrowTestID = "tooltip_arrow"
+
+    // Act
+    render(
+      <Tooltip showArrow label={label}>
+        {children}
+      </Tooltip>,
+    )
+
+    const received = screen.getByTestId(arrowTestID)
+
+    // Assert
+    await waitFor(() => expect(received).toBeInTheDocument())
+  })
+  it("allows for an enterDelay or exitDelay to be set", async () => {
+    // Arrange
+    const children = "Hello"
+    const label = "World"
+    const enterDelay = 300
+    const exitDelay = 500
+
+    // Act
+    render(
+      <Tooltip enterDelay={enterDelay} exitDelay={exitDelay} label={label}>
+        {children}
+      </Tooltip>,
+    )
+
+    const receivedChildren = screen.getByText(children)
+
+    // Assert
+    await userEvent.hover(receivedChildren)
+
+    expect(screen.getByText(label)).not.toBeVisible()
+
+    await waitFor(() => expect(screen.getByText(label)).toBeVisible(), {
+      timeout: enterDelay,
+    })
+
+    await userEvent.unhover(receivedChildren)
+
+    expect(screen.getByText(label)).toBeVisible()
+
+    await waitFor(() => expect(screen.getByText(label)).not.toBeVisible(), {
+      timeout: exitDelay,
+    })
+  })
+  it("allows for custom placement", () => {
+    placements.forEach(async (placement) => {
+      // Act
+      const children = "Hello" + placement
+      const label = "World"
+      // Act
+      render(
+        <Tooltip placement={placement} label={label}>
+          {children}
+        </Tooltip>,
+      )
+
+      const receivedChildren = screen.getByText(children)
+
+      await userEvent.hover(receivedChildren)
+
+      // Assert
+      expect(receivedChildren).toHaveAttribute(
+        "data-popper-placement",
+        placement,
+      )
+    })
   })
 })

--- a/src/components/Tooltip/Tooltip.test.tsx
+++ b/src/components/Tooltip/Tooltip.test.tsx
@@ -166,6 +166,36 @@ describe("Tooltip", () => {
       timeout: exitDelay,
     })
   })
+  it("supports aria-describedby", async () => {
+    // Arrange
+    const ariaDescribedBy = "paragraphtext"
+    const children = <b>paragraph</b>
+    const spanTestID = "tooltip_span"
+    const label =
+      "a distinct section of a piece of writing, usually dealing with a single theme and indicated by a new line, indentation, or numbering."
+
+    // Act
+    render(
+      <p>
+        This is a tooltip that lives within a{" "}
+        <Tooltip label={label} ariaDescribedBy={ariaDescribedBy}>
+          {children}
+        </Tooltip>
+        . Tooltips can be very handy for communicating additional information
+        within a body of text :).
+      </p>,
+    )
+
+    const receivedWrapper = screen.getByTestId(spanTestID)
+
+    await userEvent.hover(receivedWrapper)
+
+    const receivedTooltip = screen.getByText(label)
+
+    // Assert
+    expect(receivedWrapper).toHaveAttribute("aria-describedby", ariaDescribedBy)
+    expect(receivedTooltip.id).toEqual(ariaDescribedBy)
+  })
   it("allows for custom placement", () => {
     placements.forEach(async (placement) => {
       // Act

--- a/src/components/Tooltip/Tooltip.tsx
+++ b/src/components/Tooltip/Tooltip.tsx
@@ -59,7 +59,7 @@ export function Tooltip({
   const [anchorElement, setAnchorElement] = useState<HTMLSpanElement | null>(
     null,
   )
-  const [boxElement, setBoxElement] = useState<HTMLDivElement | null>(null)
+  const [boxElement, setBoxElement] = useState<HTMLSpanElement | null>(null)
   const arrowRef = useRef<HTMLDivElement>(null)
 
   const { styles, attributes } = usePopper(anchorElement, boxElement, {
@@ -135,13 +135,9 @@ export function Tooltip({
       >
         {children}
       </span>
-      <Transition
-        mountOnEnter
-        in={isOpen || alwaysShow}
-        timeout={animationDuration}
-      >
+      <Transition in={isOpen || alwaysShow} timeout={animationDuration}>
         {(status) => (
-          <div
+          <span
             id={ariaDescribedBy}
             role="tooltip"
             ref={setBoxElement}
@@ -162,7 +158,7 @@ export function Tooltip({
                 style={styles.arrow}
               />
             )}
-          </div>
+          </span>
         )}
       </Transition>
     </>

--- a/src/components/Tooltip/Tooltip.tsx
+++ b/src/components/Tooltip/Tooltip.tsx
@@ -14,11 +14,12 @@ import classes from "./Tooltip.module.css"
 interface TooltipProps {
   children: ReactNode
   label: string
+  ariaDescribedBy?: string
   animationDuration?: number
   alwaysShow?: boolean
   showArrow?: boolean
-  horizontalOffset?: number
-  verticalOffset?: number
+  distance?: number
+  skidding?: number
   placement?: Placement
   enterDelay?: number
   exitDelay?: number
@@ -28,12 +29,13 @@ interface TooltipProps {
 export function Tooltip({
   children,
   label,
+  ariaDescribedBy,
   animationDuration = 300,
   showArrow,
   alwaysShow,
   placement = "auto",
-  horizontalOffset = 10,
-  verticalOffset = 0,
+  distance = 10,
+  skidding = 0,
   enterDelay,
   exitDelay,
   hideOnClick,
@@ -61,7 +63,7 @@ export function Tooltip({
       { name: "arrow", options: { element: arrowRef.current } },
       {
         name: "offset",
-        options: { offset: [verticalOffset, horizontalOffset] },
+        options: { offset: [skidding, distance] },
       },
     ],
     placement,
@@ -117,7 +119,9 @@ export function Tooltip({
   return (
     <>
       <span
+        data-testid="tooltip_span"
         role={hideOnClick ? "button" : "none"}
+        aria-describedby={ariaDescribedBy}
         tabIndex={0}
         onKeyDown={handleKeyDown}
         onClick={handleClick}
@@ -130,6 +134,7 @@ export function Tooltip({
       <Transition in={isOpen || alwaysShow} timeout={animationDuration}>
         {(status) => (
           <div
+            id={ariaDescribedBy}
             role="tooltip"
             ref={boxRef}
             style={{

--- a/src/components/Tooltip/Tooltip.tsx
+++ b/src/components/Tooltip/Tooltip.tsx
@@ -28,11 +28,13 @@ export function Tooltip({
   exitDelay,
   hideOnClick,
 }: TooltipProps) {
-  const timer = useRef<NodeJS.Timeout>()
+  const enterTimeout = useRef<NodeJS.Timeout>()
+  const exitTimeout = useRef<NodeJS.Timeout>()
 
   useEffect(() => {
     return () => {
-      clearTimeout(timer.current)
+      clearTimeout(enterTimeout.current)
+      clearTimeout(exitTimeout.current)
     }
   }, [])
 
@@ -71,11 +73,21 @@ export function Tooltip({
   }
 
   const handleMouseEnter = () => {
-    timer.current = setTimeout(handleShow, enterDelay ?? 0)
+    clearTimeout(enterTimeout.current)
+    if (enterDelay) {
+      enterTimeout.current = setTimeout(handleShow, enterDelay)
+    } else {
+      handleShow()
+    }
   }
 
   const handleMouseLeave = () => {
-    timer.current = setTimeout(handleHide, exitDelay ?? 0)
+    clearTimeout(exitTimeout.current)
+    if (exitDelay) {
+      exitTimeout.current = setTimeout(handleHide, exitDelay)
+    } else {
+      handleHide()
+    }
   }
 
   return (

--- a/src/components/Tooltip/Tooltip.tsx
+++ b/src/components/Tooltip/Tooltip.tsx
@@ -1,0 +1,3 @@
+export function Tooltip() {
+  return <></>
+}

--- a/src/components/Tooltip/Tooltip.tsx
+++ b/src/components/Tooltip/Tooltip.tsx
@@ -113,7 +113,7 @@ export function Tooltip({
   }
 
   const transitionStyles: { [key in TransitionStatus]: CSSProperties } = {
-    entering: { opacity: 1 },
+    entering: { opacity: 0 },
     entered: { opacity: 1 },
     exited: {},
     exiting: {},
@@ -136,7 +136,11 @@ export function Tooltip({
       >
         {children}
       </span>
-      <Transition in={isOpen || alwaysShow} timeout={animationDuration}>
+      <Transition
+        unmountOnExit
+        in={isOpen || alwaysShow}
+        timeout={animationDuration}
+      >
         {(status) => (
           <span
             id={aria["aria-describedby"]}

--- a/src/components/Tooltip/Tooltip.tsx
+++ b/src/components/Tooltip/Tooltip.tsx
@@ -1,11 +1,20 @@
 import { Placement } from "@popperjs/core"
-import { KeyboardEvent, ReactNode, useEffect, useRef, useState } from "react"
+import {
+  CSSProperties,
+  KeyboardEvent,
+  ReactNode,
+  useEffect,
+  useRef,
+  useState,
+} from "react"
 import { usePopper } from "react-popper"
+import { Transition, TransitionStatus } from "react-transition-group"
 import classes from "./Tooltip.module.css"
 
 interface TooltipProps {
   children: ReactNode
   label: string
+  animationDuration?: number
   alwaysShow?: boolean
   showArrow?: boolean
   horizontalOffset?: number
@@ -19,6 +28,7 @@ interface TooltipProps {
 export function Tooltip({
   children,
   label,
+  animationDuration = 300,
   showArrow,
   alwaysShow,
   placement = "auto",
@@ -90,6 +100,19 @@ export function Tooltip({
     }
   }
 
+  const defaultStyle = {
+    transition: `opacity ${animationDuration}ms ease-in-out`,
+    opacity: 0,
+  }
+
+  const transitionStyles: { [key in TransitionStatus]: CSSProperties } = {
+    entering: { opacity: 1 },
+    entered: { opacity: 1 },
+    exited: {},
+    exiting: {},
+    unmounted: {},
+  }
+
   return (
     <div>
       <span
@@ -103,19 +126,30 @@ export function Tooltip({
       >
         {children}
       </span>
-      <div
-        role="tooltip"
-        ref={boxRef}
-        style={styles.popper}
-        data-is-open={isOpen || alwaysShow ? "true" : "false"}
-        className={classes.box}
-        {...attributes.popper}
-      >
-        {label}
-        {showArrow && (
-          <div ref={arrowRef} className={classes.arrow} style={styles.arrow} />
+      <Transition in={isOpen || alwaysShow} timeout={animationDuration}>
+        {(status) => (
+          <div
+            role="tooltip"
+            ref={boxRef}
+            style={{
+              ...styles.popper,
+              ...defaultStyle,
+              ...transitionStyles[status],
+            }}
+            className={classes.box}
+            {...attributes.popper}
+          >
+            {label}
+            {showArrow && (
+              <div
+                ref={arrowRef}
+                className={classes.arrow}
+                style={styles.arrow}
+              />
+            )}
+          </div>
         )}
-      </div>
+      </Transition>
     </div>
   )
 }

--- a/src/components/Tooltip/Tooltip.tsx
+++ b/src/components/Tooltip/Tooltip.tsx
@@ -1,3 +1,87 @@
-export function Tooltip() {
-  return <></>
+import { Placement } from "@popperjs/core"
+import { ReactNode, useEffect, useRef, useState } from "react"
+import { usePopper } from "react-popper"
+import classes from "./Tooltip.module.css"
+
+interface TooltipProps {
+  children: ReactNode
+  label: string
+  alwaysShow?: boolean
+  showArrow?: boolean
+  horizontalOffset?: number
+  verticalOffset?: number
+  placement?: Placement
+  enterDelay?: number
+  exitDelay?: number
+}
+
+export function Tooltip({
+  children,
+  label,
+  showArrow,
+  alwaysShow,
+  placement = "auto",
+  horizontalOffset = 10,
+  verticalOffset = 0,
+  enterDelay,
+  exitDelay,
+}: TooltipProps) {
+  const timer = useRef<NodeJS.Timeout>()
+
+  useEffect(() => {
+    return () => {
+      clearTimeout(timer.current)
+    }
+  }, [])
+
+  const [isOpen, setIsOpen] = useState(false)
+  const [anchorElement, setAnchorElement] = useState<HTMLSpanElement | null>(
+    null,
+  )
+  const boxRef = useRef<HTMLDivElement>(null)
+  const arrowRef = useRef<HTMLDivElement>(null)
+
+  const { styles, attributes } = usePopper(anchorElement, boxRef.current, {
+    modifiers: [
+      { name: "arrow", options: { element: arrowRef.current } },
+      {
+        name: "offset",
+        options: { offset: [verticalOffset, horizontalOffset] },
+      },
+    ],
+    placement,
+    strategy: "fixed",
+  })
+
+  const handleOpen = () => {
+    timer.current = setTimeout(() => setIsOpen(true), enterDelay ?? 0)
+  }
+
+  const handleClose = () => {
+    timer.current = setTimeout(() => setIsOpen(false), exitDelay ?? 0)
+  }
+
+  return (
+    <div>
+      <span
+        onMouseEnter={handleOpen}
+        onMouseLeave={handleClose}
+        ref={setAnchorElement}
+      >
+        {children}
+      </span>
+      <div
+        ref={boxRef}
+        style={styles.popper}
+        data-is-open={isOpen || alwaysShow ? "true" : "false"}
+        className={classes.box}
+        {...attributes.popper}
+      >
+        {label}
+        {showArrow && (
+          <div ref={arrowRef} className={classes.arrow} style={styles.arrow} />
+        )}
+      </div>
+    </div>
+  )
 }

--- a/src/components/Tooltip/Tooltip.tsx
+++ b/src/components/Tooltip/Tooltip.tsx
@@ -131,7 +131,6 @@ export function Tooltip({
         onMouseEnter={handleMouseEnter}
         onMouseLeave={handleMouseLeave}
         ref={setAnchorElement}
-        // ensures screen reader can read out tootlip content without displaying it
         aria-label={label}
         {...aria}
       >

--- a/src/components/Tooltip/Tooltip.tsx
+++ b/src/components/Tooltip/Tooltip.tsx
@@ -1,5 +1,6 @@
 import { Placement } from "@popperjs/core"
 import {
+  AriaAttributes,
   CSSProperties,
   KeyboardEvent,
   ReactNode,
@@ -11,10 +12,9 @@ import { usePopper } from "react-popper"
 import { Transition, TransitionStatus } from "react-transition-group"
 import classes from "./Tooltip.module.css"
 
-interface TooltipProps {
+interface TooltipProps extends Pick<AriaAttributes, "aria-describedby"> {
   children: ReactNode
   label: string
-  ariaDescribedBy?: string
   animationDuration?: number
   alwaysShow?: boolean
   showArrow?: boolean
@@ -29,7 +29,6 @@ interface TooltipProps {
 export function Tooltip({
   children,
   label,
-  ariaDescribedBy,
   animationDuration = 300,
   showArrow,
   alwaysShow,
@@ -39,6 +38,7 @@ export function Tooltip({
   enterDelay,
   exitDelay,
   hideOnClick,
+  ...aria
 }: TooltipProps) {
   const enterTimeout = useRef<NodeJS.Timeout>()
   const exitTimeout = useRef<NodeJS.Timeout>()
@@ -125,21 +125,24 @@ export function Tooltip({
       <span
         data-testid="tooltip_span"
         role={hideOnClick ? "button" : "none"}
-        aria-describedby={ariaDescribedBy}
         tabIndex={0}
         onKeyDown={handleKeyDown}
         onClick={handleClick}
         onMouseEnter={handleMouseEnter}
         onMouseLeave={handleMouseLeave}
         ref={setAnchorElement}
+        // ensures screen reader can read out tootlip content without displaying it
+        aria-label={label}
+        {...aria}
       >
         {children}
       </span>
       <Transition in={isOpen || alwaysShow} timeout={animationDuration}>
         {(status) => (
           <span
-            id={ariaDescribedBy}
+            id={aria["aria-describedby"]}
             role="tooltip"
+            data-testid="tooltip"
             ref={setBoxElement}
             style={{
               ...styles.popper,

--- a/src/components/Tooltip/Tooltip.tsx
+++ b/src/components/Tooltip/Tooltip.tsx
@@ -55,24 +55,27 @@ export function Tooltip({
     strategy: "fixed",
   })
 
-  const handleHide = () => hideOnClick && setIsOpen(false)
+  const handleShow = () => setIsOpen(true)
 
-  const handleClick = () => {
-    handleHide()
-  }
+  const handleHide = () => setIsOpen(false)
+
+  const handleClick = () => hideOnClick && handleHide()
 
   const handleKeyDown = (e: KeyboardEvent<HTMLSpanElement>) => {
-    if (e.key === "Enter") {
+    if (e.key === "Escape" && hideOnClick) {
       handleHide()
+    }
+    if (e.key === "Enter") {
+      handleShow()
     }
   }
 
-  const handleOpen = () => {
-    timer.current = setTimeout(() => setIsOpen(true), enterDelay ?? 0)
+  const handleMouseEnter = () => {
+    timer.current = setTimeout(handleShow, enterDelay ?? 0)
   }
 
-  const handleClose = () => {
-    timer.current = setTimeout(() => setIsOpen(false), exitDelay ?? 0)
+  const handleMouseLeave = () => {
+    timer.current = setTimeout(handleHide, exitDelay ?? 0)
   }
 
   return (
@@ -82,13 +85,14 @@ export function Tooltip({
         tabIndex={0}
         onKeyDown={handleKeyDown}
         onClick={handleClick}
-        onMouseEnter={handleOpen}
-        onMouseLeave={handleClose}
+        onMouseEnter={handleMouseEnter}
+        onMouseLeave={handleMouseLeave}
         ref={setAnchorElement}
       >
         {children}
       </span>
       <div
+        role="tooltip"
         ref={boxRef}
         style={styles.popper}
         data-is-open={isOpen || alwaysShow ? "true" : "false"}

--- a/src/components/Tooltip/Tooltip.tsx
+++ b/src/components/Tooltip/Tooltip.tsx
@@ -51,14 +51,18 @@ export function Tooltip({
   }, [])
 
   const [isOpen, setIsOpen] = useState(false)
-  // in order to ensure our tooltip is properly anchored, we need this state updated via the ref callback
+  /* 
+  in order to ensure all elements are properly anchored, 
+  we need these states updated via their ref callbacks
+  See docs: https://popper.js.org/react-popper/v2/#example
+  */
   const [anchorElement, setAnchorElement] = useState<HTMLSpanElement | null>(
     null,
   )
-  const boxRef = useRef<HTMLDivElement>(null)
+  const [boxElement, setBoxElement] = useState<HTMLDivElement | null>(null)
   const arrowRef = useRef<HTMLDivElement>(null)
 
-  const { styles, attributes } = usePopper(anchorElement, boxRef.current, {
+  const { styles, attributes } = usePopper(anchorElement, boxElement, {
     modifiers: [
       { name: "arrow", options: { element: arrowRef.current } },
       {
@@ -131,12 +135,16 @@ export function Tooltip({
       >
         {children}
       </span>
-      <Transition in={isOpen || alwaysShow} timeout={animationDuration}>
+      <Transition
+        mountOnEnter
+        in={isOpen || alwaysShow}
+        timeout={animationDuration}
+      >
         {(status) => (
           <div
             id={ariaDescribedBy}
             role="tooltip"
-            ref={boxRef}
+            ref={setBoxElement}
             style={{
               ...styles.popper,
               ...defaultStyle,

--- a/src/components/Tooltip/Tooltip.tsx
+++ b/src/components/Tooltip/Tooltip.tsx
@@ -49,6 +49,7 @@ export function Tooltip({
   }, [])
 
   const [isOpen, setIsOpen] = useState(false)
+  // in order to ensure our tooltip is properly anchored, we need this state updated via the ref callback
   const [anchorElement, setAnchorElement] = useState<HTMLSpanElement | null>(
     null,
   )
@@ -74,7 +75,7 @@ export function Tooltip({
   const handleClick = () => hideOnClick && handleHide()
 
   const handleKeyDown = (e: KeyboardEvent<HTMLSpanElement>) => {
-    if (e.key === "Escape" && hideOnClick) {
+    if (e.key === "Escape") {
       handleHide()
     }
     if (e.key === "Enter") {
@@ -114,7 +115,7 @@ export function Tooltip({
   }
 
   return (
-    <div>
+    <>
       <span
         role={hideOnClick ? "button" : "none"}
         tabIndex={0}
@@ -142,6 +143,7 @@ export function Tooltip({
             {label}
             {showArrow && (
               <div
+                data-testid="tooltip_arrow"
                 ref={arrowRef}
                 className={classes.arrow}
                 style={styles.arrow}
@@ -150,6 +152,6 @@ export function Tooltip({
           </div>
         )}
       </Transition>
-    </div>
+    </>
   )
 }

--- a/src/components/Tooltip/Tooltip.tsx
+++ b/src/components/Tooltip/Tooltip.tsx
@@ -1,5 +1,5 @@
 import { Placement } from "@popperjs/core"
-import { ReactNode, useEffect, useRef, useState } from "react"
+import { KeyboardEvent, ReactNode, useEffect, useRef, useState } from "react"
 import { usePopper } from "react-popper"
 import classes from "./Tooltip.module.css"
 
@@ -13,6 +13,7 @@ interface TooltipProps {
   placement?: Placement
   enterDelay?: number
   exitDelay?: number
+  hideOnClick?: boolean
 }
 
 export function Tooltip({
@@ -25,6 +26,7 @@ export function Tooltip({
   verticalOffset = 0,
   enterDelay,
   exitDelay,
+  hideOnClick,
 }: TooltipProps) {
   const timer = useRef<NodeJS.Timeout>()
 
@@ -53,6 +55,18 @@ export function Tooltip({
     strategy: "fixed",
   })
 
+  const handleHide = () => hideOnClick && setIsOpen(false)
+
+  const handleClick = () => {
+    handleHide()
+  }
+
+  const handleKeyDown = (e: KeyboardEvent<HTMLSpanElement>) => {
+    if (e.key === "Enter") {
+      handleHide()
+    }
+  }
+
   const handleOpen = () => {
     timer.current = setTimeout(() => setIsOpen(true), enterDelay ?? 0)
   }
@@ -64,6 +78,10 @@ export function Tooltip({
   return (
     <div>
       <span
+        role={hideOnClick ? "button" : "none"}
+        tabIndex={0}
+        onKeyDown={handleKeyDown}
+        onClick={handleClick}
         onMouseEnter={handleOpen}
         onMouseLeave={handleClose}
         ref={setAnchorElement}

--- a/src/components/Tooltip/index.ts
+++ b/src/components/Tooltip/index.ts
@@ -1,0 +1,1 @@
+export { Tooltip } from "./Tooltip"

--- a/src/components/Tooltip/placements.ts
+++ b/src/components/Tooltip/placements.ts
@@ -1,0 +1,13 @@
+import { Placement } from "@popperjs/core"
+
+const basePlacement = ["top", "bottom", "left", "right", "auto"]
+const startPlacement = basePlacement.map((placement) => `${placement}-start`)
+const endPlacement = basePlacement.map((placement) => `${placement}-end`)
+
+// while @popperjs/core has its own placements array, in some cases the export is undefined, specifically within a testing environment
+
+export const placements = [
+  ...basePlacement,
+  ...startPlacement,
+  ...endPlacement,
+] as Placement[]

--- a/src/components/Tooltip/placements.ts
+++ b/src/components/Tooltip/placements.ts
@@ -1,13 +1,16 @@
 import { Placement } from "@popperjs/core"
 
-const basePlacement = ["top", "bottom", "left", "right", "auto"]
-const startPlacement = basePlacement.map((placement) => `${placement}-start`)
-const endPlacement = basePlacement.map((placement) => `${placement}-end`)
+const basePlacement = ["top", "bottom", "left", "right", "auto"] as const
+const startPlacement = basePlacement.map(
+  (placement) => `${placement}-start` as const,
+)
+const endPlacement = basePlacement.map(
+  (placement) => `${placement}-end` as const,
+)
 
 // while @popperjs/core has its own placements array, in some cases the export is undefined, specifically within a testing environment
-
-export const placements = [
+export const placements: Placement[] = [
   ...basePlacement,
   ...startPlacement,
   ...endPlacement,
-] as Placement[]
+]


### PR DESCRIPTION
## Description

A simple `<Tooltip />` component for displaying non-interactive descriptive text that is anchored to its child element. Supports keyboard accessibility.

[See it in the wild](https://www.justinklaas.com/projects/1) (hover over the tech icons)

### 🔗 Reference

> _Relevant links (e.g. issue, design, etc.)_

- [Issues #28](https://github.com/cremalab/crema-components/issues/28)

### 📋 Acceptance Criteria

> _Checked off by PR **Assignees**_

- [ ] CRITERION_HERE


### 🖼 Demo

https://user-images.githubusercontent.com/46500734/183151137-492a3cb6-d929-4276-ab26-3e2bc469bf6a.mov

<!-- If applicable, use "Before/After Table" located at end of file -->

### 👩‍🔬 Test Instructions

> _Provided by PR **Assignees**_

1. run `npm run test:playground`
2. ensure tooltip behaves as intended

## 🔎 Reviewer Checklist

> _Checked off by PR **Reviewers**_

- [ ] Merge destination is correct
- [ ] Code is correct as understood and conforms to quality standards
- [ ] Tests have been added where appropriate (unit, visual, end-to-end)
- [ ] Acceptance Criteria have been met

<!--
Optional additions:
- [ ] Code has been tested and confirmed locally
-->

---

> ### Roles & Responsibilities
>
> #### 👨‍💻 Assignee
>
> - Initiator of this PR (be sure to set in GitHub UI)
> - Addresses feedback and change requests
> - Merges PR once approved (usually deletes branch unless `develop` or `release`)
>
> #### 👩‍💻 Reviewer
>
> - Invited to review PR by **Assignee** (via GitHub UI)
> - Is expected to complete a review and address followup

<!--
## Before/After Table

<table>
<tr><th>Before</th><th>After</th></tr>
<tr>
<td>

![](BEFORE_IMAGE_LINK_HERE)

</td>
<td>

![](AFTER_IMAGE_LINK_HERE)

</td>
</tr>
</table>
-->
