### PR TITLE
Feature/Avatar

### DIFF
--- a/src/components/Avatar/Avatar.module.css
+++ b/src/components/Avatar/Avatar.module.css
@@ -32,4 +32,3 @@
   width: var(--large);
   height: var(--large);
 }
-

--- a/src/components/Avatar/Avatar.module.css
+++ b/src/components/Avatar/Avatar.module.css
@@ -10,23 +10,20 @@
 }
 
 .container[data-size="small"] {
-  font-size: 14px;
+  font-size: 24px;
   width: 48px;
   height: 48px;
-  padding: 8px;
 }
 
 .container[data-size="medium"] {
-  font-size: 18px;
+  font-size: 32px;
   width: 64px;
   height: 64px;
-  padding: 16px;
 }
 
 .container[data-size="large"] {
-  font-size: 24px;
-  width: 72px;
-  height: 72px;
-  padding: 16px;
+  font-size: 48px;
+  width: 96px;
+  height: 96px;
 }
 

--- a/src/components/Avatar/Avatar.module.css
+++ b/src/components/Avatar/Avatar.module.css
@@ -2,6 +2,7 @@
   --small: 48px;
   --medium: 64px;
   --large: 96px;
+  --ratio: 0.5;
 }
 
 .container {
@@ -16,19 +17,19 @@
 }
 
 .container[data-size="sm"] {
-  font-size: calc(var(--small) * 0.5);
+  font-size: calc(var(--small) * var(--ratio));
   width: var(--small);
   height: var(--small);
 }
 
 .container[data-size="md"] {
-  font-size: calc(var(--medium) * 0.5);
+  font-size: calc(var(--medium) * var(--ratio));
   width: var(--medium);
   height: var(--medium);
 }
 
 .container[data-size="lg"] {
-  font-size: calc(var(--large) * 0.5);
+  font-size: calc(var(--large) * var(--ratio));
   width: var(--large);
   height: var(--large);
 }

--- a/src/components/Avatar/Avatar.module.css
+++ b/src/components/Avatar/Avatar.module.css
@@ -1,0 +1,32 @@
+.container {
+  background: #999999;
+  color: #333333;
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  border-radius: 100%;
+  flex-wrap: nowrap;
+  background-size: cover;
+}
+
+.container[data-size="small"] {
+  font-size: 14px;
+  width: 48px;
+  height: 48px;
+  padding: 8px;
+}
+
+.container[data-size="medium"] {
+  font-size: 18px;
+  width: 64px;
+  height: 64px;
+  padding: 16px;
+}
+
+.container[data-size="large"] {
+  font-size: 24px;
+  width: 72px;
+  height: 72px;
+  padding: 16px;
+}
+

--- a/src/components/Avatar/Avatar.module.css
+++ b/src/components/Avatar/Avatar.module.css
@@ -1,11 +1,8 @@
-:root {
+.container {
   --small: 48px;
   --medium: 64px;
   --large: 96px;
   --ratio: 0.5;
-}
-
-.container {
   background: #999999;
   color: #333333;
   display: flex;

--- a/src/components/Avatar/Avatar.module.css
+++ b/src/components/Avatar/Avatar.module.css
@@ -15,19 +15,19 @@
   background-size: cover;
 }
 
-.container[data-size="small"] {
+.container[data-size="sm"] {
   font-size: calc(var(--small) * 0.5);
   width: var(--small);
   height: var(--small);
 }
 
-.container[data-size="medium"] {
+.container[data-size="md"] {
   font-size: calc(var(--medium) * 0.5);
   width: var(--medium);
   height: var(--medium);
 }
 
-.container[data-size="large"] {
+.container[data-size="lg"] {
   font-size: calc(var(--large) * 0.5);
   width: var(--large);
   height: var(--large);

--- a/src/components/Avatar/Avatar.module.css
+++ b/src/components/Avatar/Avatar.module.css
@@ -1,3 +1,9 @@
+:root {
+  --small: 48px;
+  --medium: 64px;
+  --large: 96px;
+}
+
 .container {
   background: #999999;
   color: #333333;
@@ -10,20 +16,20 @@
 }
 
 .container[data-size="small"] {
-  font-size: 24px;
-  width: 48px;
-  height: 48px;
+  font-size: calc(var(--small) * 0.5);
+  width: var(--small);
+  height: var(--small);
 }
 
 .container[data-size="medium"] {
-  font-size: 32px;
-  width: 64px;
-  height: 64px;
+  font-size: calc(var(--medium) * 0.5);
+  width: var(--medium);
+  height: var(--medium);
 }
 
 .container[data-size="large"] {
-  font-size: 48px;
-  width: 96px;
-  height: 96px;
+  font-size: calc(var(--large) * 0.5);
+  width: var(--large);
+  height: var(--large);
 }
 

--- a/src/components/Avatar/Avatar.stories.tsx
+++ b/src/components/Avatar/Avatar.stories.tsx
@@ -1,4 +1,3 @@
-import decoratorCentered from "@storybook/addon-centered"
 import { ComponentStory } from "@storybook/react"
 import { Avatar } from "./Avatar"
 
@@ -9,7 +8,9 @@ import { Avatar } from "./Avatar"
 
 export default {
   title: "Components/Avatar",
-  decorators: [decoratorCentered],
+  parameters: {
+    layout: "centered",
+  },
 }
 
 const Template: ComponentStory<typeof Avatar> = (args) => <Avatar {...args} />

--- a/src/components/Avatar/Avatar.stories.tsx
+++ b/src/components/Avatar/Avatar.stories.tsx
@@ -1,4 +1,5 @@
 import decoratorCentered from "@storybook/addon-centered"
+import { ComponentStory } from "@storybook/react"
 import { Avatar } from "./Avatar"
 
 /**
@@ -7,8 +8,34 @@ import { Avatar } from "./Avatar"
  */
 
 export default {
-  title: "Avatar",
+  title: "Components/Avatar",
   decorators: [decoratorCentered],
 }
 
-export const Example = () => <Avatar />
+const Template: ComponentStory<typeof Avatar> = (args) => <Avatar {...args} />
+
+export const Basic = Template.bind({})
+
+Basic.args = {
+  name: "Crema Components",
+}
+
+export const Small = Template.bind({})
+
+Small.args = { ...Basic.args, size: "small" }
+
+export const Medium = Template.bind({})
+
+Medium.args = { ...Basic.args, size: "medium" }
+
+export const Large = Template.bind({})
+
+Large.args = { ...Basic.args, size: "large" }
+
+export const WithImage = Template.bind({})
+
+WithImage.args = {
+  ...Basic.args,
+  size: "large",
+  src: "https://assets.website-files.com/5b6b50e79e9b6f7d0d3959a2/614a3f0710df4f2ff20e5bbd_JustinK.jpg",
+}

--- a/src/components/Avatar/Avatar.stories.tsx
+++ b/src/components/Avatar/Avatar.stories.tsx
@@ -22,20 +22,20 @@ Basic.args = {
 
 export const Small = Template.bind({})
 
-Small.args = { ...Basic.args, size: "small" }
+Small.args = { ...Basic.args, size: "sm" }
 
 export const Medium = Template.bind({})
 
-Medium.args = { ...Basic.args, size: "medium" }
+Medium.args = { ...Basic.args, size: "md" }
 
 export const Large = Template.bind({})
 
-Large.args = { ...Basic.args, size: "large" }
+Large.args = { ...Basic.args, size: "lg" }
 
 export const WithImage = Template.bind({})
 
 WithImage.args = {
   ...Basic.args,
-  size: "large",
+  size: "lg",
   src: "https://assets.website-files.com/5b6b50e79e9b6f7d0d3959a2/614a3f0710df4f2ff20e5bbd_JustinK.jpg",
 }

--- a/src/components/Avatar/Avatar.stories.tsx
+++ b/src/components/Avatar/Avatar.stories.tsx
@@ -1,15 +1,23 @@
 import { ComponentStory } from "@storybook/react"
-import { Avatar } from "./Avatar"
+import { Avatar, AvatarSize } from "./Avatar"
 
 /**
  * See Storybook Docs: Writing Stories
  * https://storybook.js.org/docs/basics/writing-stories/
  */
 
+const options: AvatarSize[] = ["sm", "md", "lg"]
+
 export default {
   title: "Components/Avatar",
   parameters: {
     layout: "centered",
+  },
+  argTypes: {
+    size: {
+      control: "select",
+      options,
+    },
   },
 }
 

--- a/src/components/Avatar/Avatar.stories.tsx
+++ b/src/components/Avatar/Avatar.stories.tsx
@@ -1,5 +1,5 @@
 import { ComponentStory } from "@storybook/react"
-import { Avatar, AvatarSize } from "./Avatar"
+import { Avatar, AvatarSize } from "."
 
 /**
  * See Storybook Docs: Writing Stories

--- a/src/components/Avatar/Avatar.stories.tsx
+++ b/src/components/Avatar/Avatar.stories.tsx
@@ -1,0 +1,14 @@
+import decoratorCentered from "@storybook/addon-centered"
+import { Avatar } from "./Avatar"
+
+/**
+ * See Storybook Docs: Writing Stories
+ * https://storybook.js.org/docs/basics/writing-stories/
+ */
+
+export default {
+  title: "Avatar",
+  decorators: [decoratorCentered],
+}
+
+export const Example = () => <Avatar />

--- a/src/components/Avatar/Avatar.test.tsx
+++ b/src/components/Avatar/Avatar.test.tsx
@@ -16,6 +16,7 @@ describe("Avatar", () => {
     // Assert
     expect(received).toBeInTheDocument()
   })
+
   it("does not render initials if image is supplied", () => {
     // Arrange
     const name = "Crema Components"
@@ -29,6 +30,7 @@ describe("Avatar", () => {
     // Assert
     expect(received).not.toBeInTheDocument()
   })
+
   it("renders an aria label when an image is supplied", () => {
     // Arrange
     const name = "Crema Components"
@@ -42,6 +44,7 @@ describe("Avatar", () => {
     // Assert
     expect(label).toBeInTheDocument()
   })
+
   it("renders an aria label when an image is not supplied", () => {
     // Arrange
     const name = "Crema Components"
@@ -55,6 +58,7 @@ describe("Avatar", () => {
     // Assert
     expect(label).toBeInTheDocument()
   })
+
   it("renders 3 sizes of avatars", () => {
     // Arrange
     const sizes: AvatarSize[] = ["sm", "md", "lg"]

--- a/src/components/Avatar/Avatar.test.tsx
+++ b/src/components/Avatar/Avatar.test.tsx
@@ -66,6 +66,7 @@ describe("Avatar", () => {
     sizes.forEach((size) => {
       // Act
       const label = `An avatar with initials for ${size}`
+
       render(<Avatar size={size} name={size} />)
 
       const received = screen.getByLabelText(label)

--- a/src/components/Avatar/Avatar.test.tsx
+++ b/src/components/Avatar/Avatar.test.tsx
@@ -1,7 +1,19 @@
+import { render, screen } from "@testing-library/react"
 import { Avatar } from "./Avatar"
+import { getInitials } from "./utils/getInitials"
 
 describe("Avatar", () => {
-  it("is defined", expect(Avatar).toBeDefined)
+  it("renders an avatar with initials", () => {
+    // Arrange
+    const name = "Crema Components"
+    const initials = getInitials(name)
 
-  it.todo(`add meaningful tests 👍`)
+    // Act
+    render(<Avatar name={name} />)
+
+    const received = screen.getByText(initials)
+
+    // Assert
+    expect(received).toBeInTheDocument()
+  })
 })

--- a/src/components/Avatar/Avatar.test.tsx
+++ b/src/components/Avatar/Avatar.test.tsx
@@ -1,5 +1,5 @@
 import { render, screen } from "@testing-library/react"
-import { Avatar } from "./Avatar"
+import { Avatar, AvatarSize } from "./Avatar"
 import { getInitials } from "./utils/getInitials"
 
 describe("Avatar", () => {
@@ -29,20 +29,45 @@ describe("Avatar", () => {
     // Assert
     expect(received).not.toBeInTheDocument()
   })
-  it("renders a meaningful aria label when an image is supplied", () => {
+  it("renders an aria label when an image is supplied", () => {
     // Arrange
     const name = "Crema Components"
-    const initials = getInitials(name)
-    const ariaLabel = `An image of ${name}`
+    const ariaLabel = `An avatar with an image of ${name}`
 
     // Act
     render(<Avatar name={name} src="someUrl" />)
 
-    const received = screen.queryByText(initials)
     const label = screen.getByLabelText(ariaLabel)
 
     // Assert
-    expect(received).not.toBeInTheDocument()
     expect(label).toBeInTheDocument()
+  })
+  it("renders an aria label when an image is not supplied", () => {
+    // Arrange
+    const name = "Crema Components"
+    const ariaLabel = `An avatar with initials for ${name}`
+
+    // Act
+    render(<Avatar name={name} />)
+
+    const label = screen.getByLabelText(ariaLabel)
+
+    // Assert
+    expect(label).toBeInTheDocument()
+  })
+  it("renders 3 sizes of avatars", () => {
+    // Arrange
+    const sizes: AvatarSize[] = ["sm", "md", "lg"]
+
+    sizes.forEach((size) => {
+      // Act
+      const label = `An avatar with initials for ${size}`
+      render(<Avatar size={size} name={size} />)
+
+      const received = screen.getByLabelText(label)
+
+      // Assert
+      expect(received).toHaveAttribute("data-size", size)
+    })
   })
 })

--- a/src/components/Avatar/Avatar.test.tsx
+++ b/src/components/Avatar/Avatar.test.tsx
@@ -1,6 +1,6 @@
 import { render, screen } from "@testing-library/react"
-import { Avatar, AvatarSize } from "./Avatar"
 import { getInitials } from "./utils/getInitials"
+import { Avatar, AvatarSize } from "."
 
 describe("Avatar", () => {
   it("renders an avatar with initials", () => {

--- a/src/components/Avatar/Avatar.test.tsx
+++ b/src/components/Avatar/Avatar.test.tsx
@@ -16,4 +16,33 @@ describe("Avatar", () => {
     // Assert
     expect(received).toBeInTheDocument()
   })
+  it("does not render initials if image is supplied", () => {
+    // Arrange
+    const name = "Crema Components"
+    const initials = getInitials(name)
+
+    // Act
+    render(<Avatar name={name} src="someUrl" />)
+
+    const received = screen.queryByText(initials)
+
+    // Assert
+    expect(received).not.toBeInTheDocument()
+  })
+  it("renders a meaningful aria label when an image is supplied", () => {
+    // Arrange
+    const name = "Crema Components"
+    const initials = getInitials(name)
+    const ariaLabel = `An image of ${name}`
+
+    // Act
+    render(<Avatar name={name} src="someUrl" />)
+
+    const received = screen.queryByText(initials)
+    const label = screen.getByLabelText(ariaLabel)
+
+    // Assert
+    expect(received).not.toBeInTheDocument()
+    expect(label).toBeInTheDocument()
+  })
 })

--- a/src/components/Avatar/Avatar.test.tsx
+++ b/src/components/Avatar/Avatar.test.tsx
@@ -1,0 +1,7 @@
+import { Avatar } from "./Avatar"
+
+describe("Avatar", () => {
+  it("is defined", expect(Avatar).toBeDefined)
+
+  it.todo(`add meaningful tests 👍`)
+})

--- a/src/components/Avatar/Avatar.tsx
+++ b/src/components/Avatar/Avatar.tsx
@@ -1,9 +1,11 @@
 import styles from "./Avatar.module.css"
 import { getInitials } from "./utils/getInitials"
 
+export type AvatarSize = "sm" | "md" | "lg"
+
 interface AvatarProps {
   name?: string
-  size?: "sm" | "md" | "lg"
+  size?: AvatarSize
   src?: string
 }
 

--- a/src/components/Avatar/Avatar.tsx
+++ b/src/components/Avatar/Avatar.tsx
@@ -8,12 +8,11 @@ interface AvatarProps {
 }
 
 export function Avatar({ name, size = "small", src }: AvatarProps) {
-  const initials = getInitials(name)
-
   const Child = () => {
     if (src) {
       return null
     } else {
+      const initials = getInitials(name)
       return <div className={styles.text}>{initials}</div>
     }
   }

--- a/src/components/Avatar/Avatar.tsx
+++ b/src/components/Avatar/Avatar.tsx
@@ -4,12 +4,12 @@ import { getInitials } from "./utils/getInitials"
 export type AvatarSize = "sm" | "md" | "lg"
 
 interface AvatarProps {
-  name?: string
+  name: string
   size?: AvatarSize
   src?: string
 }
 
-export function Avatar({ name = "", size = "sm", src }: AvatarProps) {
+export function Avatar({ name, size = "sm", src }: AvatarProps) {
   const Child = () => {
     if (src) {
       return null
@@ -19,8 +19,11 @@ export function Avatar({ name = "", size = "sm", src }: AvatarProps) {
     }
   }
 
+  const aria = src ? { "aria-label": `An image of ${name}` } : {}
+
   return (
     <div
+      {...aria}
       style={{
         backgroundImage: `url(${src})`,
       }}

--- a/src/components/Avatar/Avatar.tsx
+++ b/src/components/Avatar/Avatar.tsx
@@ -1,3 +1,28 @@
-export function Avatar() {
-  return <></>
+import styles from "./Avatar.module.css"
+import { getInitials } from "./utils/getInitials"
+
+interface AvatarProps {
+  name: string
+  size: "small" | "medium" | "large"
+  src?: string
+}
+
+const shouldShowInitials = (src?: string) => {
+  return !src
+}
+
+export function Avatar({ name, size = "small", src }: AvatarProps) {
+  const initials = getInitials(name)
+
+  return (
+    <div
+      style={{
+        backgroundImage: `url(${src})`,
+      }}
+      className={styles.container}
+      data-size={size}
+    >
+      {shouldShowInitials(src) && <div className={styles.text}>{initials}</div>}
+    </div>
+  )
 }

--- a/src/components/Avatar/Avatar.tsx
+++ b/src/components/Avatar/Avatar.tsx
@@ -19,11 +19,13 @@ export function Avatar({ name, size = "sm", src }: AvatarProps) {
     }
   }
 
-  const aria = src ? { "aria-label": `An image of ${name}` } : {}
+  const ariaLabel = src
+    ? `An avatar with an image of ${name}`
+    : `An avatar with initials for ${name}`
 
   return (
     <div
-      {...aria}
+      aria-label={ariaLabel}
       style={{
         backgroundImage: `url(${src})`,
       }}

--- a/src/components/Avatar/Avatar.tsx
+++ b/src/components/Avatar/Avatar.tsx
@@ -2,12 +2,12 @@ import styles from "./Avatar.module.css"
 import { getInitials } from "./utils/getInitials"
 
 interface AvatarProps {
-  name: string
-  size: "small" | "medium" | "large"
+  name?: string
+  size?: "sm" | "md" | "lg"
   src?: string
 }
 
-export function Avatar({ name, size = "small", src }: AvatarProps) {
+export function Avatar({ name = "", size = "sm", src }: AvatarProps) {
   const Child = () => {
     if (src) {
       return null

--- a/src/components/Avatar/Avatar.tsx
+++ b/src/components/Avatar/Avatar.tsx
@@ -7,12 +7,16 @@ interface AvatarProps {
   src?: string
 }
 
-const shouldShowInitials = (src?: string) => {
-  return !src
-}
-
 export function Avatar({ name, size = "small", src }: AvatarProps) {
   const initials = getInitials(name)
+
+  const Child = () => {
+    if (src) {
+      return null
+    } else {
+      return <div className={styles.text}>{initials}</div>
+    }
+  }
 
   return (
     <div
@@ -22,7 +26,7 @@ export function Avatar({ name, size = "small", src }: AvatarProps) {
       className={styles.container}
       data-size={size}
     >
-      {shouldShowInitials(src) && <div className={styles.text}>{initials}</div>}
+      <Child />
     </div>
   )
 }

--- a/src/components/Avatar/Avatar.tsx
+++ b/src/components/Avatar/Avatar.tsx
@@ -1,0 +1,3 @@
+export function Avatar() {
+  return <></>
+}

--- a/src/components/Avatar/README.md
+++ b/src/components/Avatar/README.md
@@ -1,6 +1,6 @@
 # `<Avatar />`
 
-DESCRIPTION_HERE
+A component for rendering a circular container used to display a user's initials or an image of a user.
 
 ## Directory Structure
 
@@ -9,3 +9,17 @@ DESCRIPTION_HERE
 - `Avatar.tsx`: Component code
 - `index.ts`: Component export
 - `README.md`: Component documentation (hey, that's me!)
+
+## Example Usage
+
+```tsx
+<Avatar name="Crema Components" size="md" src="https://www.someurl.com/someimage.jpg">
+```
+
+## API
+
+| Prop   | Type   | Required | Description      | Default |
+| ------ | ------ | -------- | ---------------- | ------- |
+| `name` | string | yes      | A user's name    |         |
+| `size` | string | no       | the avatar size  | "sm"    |
+| `src`  | string | no       | the image source |         |

--- a/src/components/Avatar/README.md
+++ b/src/components/Avatar/README.md
@@ -1,0 +1,11 @@
+# `<Avatar />`
+
+DESCRIPTION_HERE
+
+## Directory Structure
+
+- `Avatar.stories.tsx`: Component stories (`npm run test:playground`)
+- `Avatar.test.tsx`: Component tests (`npm run test:unit`)
+- `Avatar.tsx`: Component code
+- `index.ts`: Component export
+- `README.md`: Component documentation (hey, that's me!)

--- a/src/components/Avatar/index.ts
+++ b/src/components/Avatar/index.ts
@@ -1,0 +1,1 @@
+export { Avatar } from "./Avatar"

--- a/src/components/Avatar/index.ts
+++ b/src/components/Avatar/index.ts
@@ -1,1 +1,1 @@
-export { Avatar } from "./Avatar"
+export { Avatar, type AvatarSize } from "./Avatar"

--- a/src/components/Avatar/utils/getInitials/getInitials.test.tsx
+++ b/src/components/Avatar/utils/getInitials/getInitials.test.tsx
@@ -7,31 +7,30 @@ describe("getInitials", () => {
 
     // Act
     const initials = getInitials(name)
-
     const expected = "CC"
 
     // Assert
     expect(initials).toBe(expected)
   })
+
   it("capitalizes each initial", () => {
     // Arrange
     const name = "hello world"
 
     // Act
     const initials = getInitials(name)
-
     const expected = "HW"
 
     // Assert
     expect(initials).toBe(expected)
   })
+
   it("generates initials for complex names", () => {
     // Arrange
     const name = "This is a complext name"
 
     // Act
     const initials = getInitials(name)
-
     const expected = "TN"
 
     // Assert

--- a/src/components/Avatar/utils/getInitials/getInitials.test.tsx
+++ b/src/components/Avatar/utils/getInitials/getInitials.test.tsx
@@ -1,0 +1,40 @@
+import { getInitials } from "./getInitials"
+
+describe("getInitials", () => {
+  it("takes in a name and returns the first and maybe last initial", () => {
+    // Arrange
+    const name = "Crema Components"
+
+    // Act
+    const initials = getInitials(name)
+
+    const expected = "CC"
+
+    // Assert
+    expect(initials).toBe(expected)
+  })
+  it("capitalizes each initial", () => {
+    // Arrange
+    const name = "hello world"
+
+    // Act
+    const initials = getInitials(name)
+
+    const expected = "HW"
+
+    // Assert
+    expect(initials).toBe(expected)
+  })
+  it("generates initials for complex names", () => {
+    // Arrange
+    const name = "This is a complext name"
+
+    // Act
+    const initials = getInitials(name)
+
+    const expected = "TN"
+
+    // Assert
+    expect(initials).toBe(expected)
+  })
+})

--- a/src/components/Avatar/utils/getInitials/getInitials.ts
+++ b/src/components/Avatar/utils/getInitials/getInitials.ts
@@ -1,11 +1,5 @@
-const capitalize = (str: string) => str.toUpperCase()
-
-const getFirstChar = (str: string) => str.charAt(0)
-
 const getInitial = (str: string) => {
-  const firstChar = getFirstChar(str)
-  const capitalized = capitalize(firstChar)
-  return capitalized
+  return str.charAt(0).toUpperCase()
 }
 
 const getInitialArray = (name: string) => {

--- a/src/components/Avatar/utils/getInitials/getInitials.ts
+++ b/src/components/Avatar/utils/getInitials/getInitials.ts
@@ -1,0 +1,14 @@
+const capitalize = (str: string) => str.toUpperCase()
+
+const getFirstChar = (str: string) => str.charAt(0)
+
+const getInitialsArray = (name: string) => {
+  return name.split(" ").map(capitalize).map(getFirstChar)
+}
+
+export const getInitials = (name: string) => {
+  const initialsArray = getInitialsArray(name)
+  const firstInitial = initialsArray[0]
+  const lastInitial = initialsArray[initialsArray.length - 1] ?? ""
+  return `${firstInitial}${lastInitial}`
+}

--- a/src/components/Avatar/utils/getInitials/getInitials.ts
+++ b/src/components/Avatar/utils/getInitials/getInitials.ts
@@ -8,13 +8,13 @@ const getInitial = (str: string) => {
   return capitalized
 }
 
-const getInitialsArray = (name: string) => {
+const getInitialArray = (name: string) => {
   return name.split(" ").map(getInitial)
 }
 
 export const getInitials = (name: string) => {
-  const initialsArray = getInitialsArray(name)
-  const firstInitial = initialsArray[0]
-  const lastInitial = initialsArray[initialsArray.length - 1] ?? ""
+  const initialArray = getInitialArray(name)
+  const firstInitial = initialArray[0]
+  const lastInitial = initialArray[initialArray.length - 1] ?? ""
   return `${firstInitial}${lastInitial}`
 }

--- a/src/components/Avatar/utils/getInitials/getInitials.ts
+++ b/src/components/Avatar/utils/getInitials/getInitials.ts
@@ -2,8 +2,14 @@ const capitalize = (str: string) => str.toUpperCase()
 
 const getFirstChar = (str: string) => str.charAt(0)
 
+const getInitial = (str: string) => {
+  const firstChar = getFirstChar(str)
+  const capitalized = capitalize(firstChar)
+  return capitalized
+}
+
 const getInitialsArray = (name: string) => {
-  return name.split(" ").map(capitalize).map(getFirstChar)
+  return name.split(" ").map(getInitial)
 }
 
 export const getInitials = (name: string) => {

--- a/src/components/Avatar/utils/getInitials/index.ts
+++ b/src/components/Avatar/utils/getInitials/index.ts
@@ -1,0 +1,1 @@
+export { getInitials } from "./getInitials"


### PR DESCRIPTION
## Description

A `<Avatar />` component for rendering a circular container used to display a user's initials or an image of a user.

### 🔗 Reference

> _Relevant links (e.g. issue, design, etc.)_

- [LINK_NAME](LINK_URL)

### 📋 Acceptance Criteria

> _Checked off by PR **Assignees**_

- [ ] It should always take in a name
- [ ] Its default is to display a first and last initial (if applicable).
- [ ] It takes an optional img src to display an image instead of initials.
- [ ] It can be rendered in different sizes.


### 🖼 Demo

https://user-images.githubusercontent.com/46500734/186004886-7c89158a-7c7c-4693-837b-76f97f35b436.mov




<!-- If applicable, use "Before/After Table" located at end of file -->

### 👩‍🔬 Test Instructions

> _Provided by PR **Assignees**_

1. TEST_STEP_HERE

## 🔎 Reviewer Checklist

> _Checked off by PR **Reviewers**_

- [ ] Merge destination is correct
- [ ] Code is correct as understood and conforms to quality standards
- [ ] Tests have been added where appropriate (unit, visual, end-to-end)
- [ ] Acceptance Criteria have been met

<!--
Optional additions:
- [ ] Code has been tested and confirmed locally
-->

---

> ### Roles & Responsibilities
>
> #### 👨‍💻 Assignee
>
> - Initiator of this PR (be sure to set in GitHub UI)
> - Addresses feedback and change requests
> - Merges PR once approved (usually deletes branch unless `develop` or `release`)
>
> #### 👩‍💻 Reviewer
>
> - Invited to review PR by **Assignee** (via GitHub UI)
> - Is expected to complete a review and address followup

<!--
## Before/After Table

<table>
<tr><th>Before</th><th>After</th></tr>
<tr>
<td>

![](BEFORE_IMAGE_LINK_HERE)

</td>
<td>

![](AFTER_IMAGE_LINK_HERE)

</td>
</tr>
</table>
-->
